### PR TITLE
use new soroban cli subcommand format in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,36 +19,38 @@ docker run --platform linux/amd64 --rm -it --name e2e_test stellar/system-test:l
 
 Optional settings:
 
-To compile soroban tools components from local source on host machine instead of package versions. Usage of either of these two requires adding a docker volume mount to your local cloned copy of soroban-tools git repo `-v /full/path/to/soroban-tools:/soroban-tools`
+To compile soroban tools components from local source on host machine instead of package versions. Usage of either of these two requires adding a docker volume mount to your local cloned copy of soroban-tools git repo  
+`-v /full/path/to/soroban-tools:/soroban-tools`
 
-to compile local copy of cli source code, include this parameter, if empty it uses `--SorobanCLICrateVersion` instead. 
-`--SorobanCLISourceVolume=/soroban-tools`
+* to compile local copy of cli source code, include this parameter, if empty it uses `--SorobanCLICrateVersion` instead:  
+`--SorobanCLISourceVolume /soroban-tools`
 
-to compile local copy of rpc source code, set this paramter, if empty it uses `--SorobanRPCDebianVersion` instead.
-`--SorobanRPCSourceVolume=/soroban-tools`
+* to compile local copy of rpc source code, set this paramter, if empty it uses `--SorobanRPCDebianVersion` instead:  
+`--SorobanRPCSourceVolume /soroban-tools`
 
-To specify git version of the smart contract source code used as test fixtures. 
-`--SorobanExamplesGitHash {branch, tag, git commit hash}` 
+To specify git version of the smart contract source code used as test fixtures.  
+`--SorobanExamplesGitHash {branch, tag, git commit hash}`  
 `--SorobanExamplesRepoURL "https://github.com/stellar/soroban-examples.git"` 
 
-Default rust toolchain version in system test image was 1.65.0, to override and install different:
+Default rust toolchain version in system test image was 1.65.0, to override and install different:  
 `--RustToolchainVersion {version}`
 
-To specify which system test feature/scenarios to run, it is a regex of the feature test name and a scenario defined within, each row in example data for a scenario outline is postfixed with '#01', '#02', examples:
-`--TestFilter "^TestDappDevelop$/^DApp developer compiles, deploys and invokes a contract.*$"`
-or
-`--TestFilter "^TestDappDevelop$/^DApp developer compiles, deploys and invokes a contract#01$"`
+To specify which system test feature/scenarios to run, it is a regex of the feature test name and a scenario defined within, each row in example data for a scenario outline is postfixed with '#01', '#02', examples:  
+`--TestFilter "^TestDappDevelop$/^DApp developer compiles, deploys and invokes a contract.*$"`  
+or  
+`--TestFilter "^TestDappDevelop$/^DApp developer compiles, deploys and invokes a contract#01$"`  
 
 The ending wildcard allows for all combinations of example data for a scenario outline, without that it would just run the first example data set in a scenario outline.
 
-Default target network for system tests is new/empty instance of standalone network, and tests will use the default root account already seeded into standalone network, can override here.
-`--TargetNetwork {standalone|futurenet}`
-`--TargetNetworkPassphrase "{passphrase}"`
-`--TargetNetworkTestAccountSecret "{your test account key pair info}"`
-`--TargetNetworkTestAccountPublic "{your test account key pair info}"`
+The default target network for system tests is a new/empty instance of standalone network hosted inside the docker container, tests will use the default root account already seeded into standalone network. Alternatively, can override the network settings here:  
+`--TargetNetwork {standalone|futurenet}` \\ sets the internally hosted network to either standalone or futurenet  
+`--TargetNetworkRPCURL {http://<rpc_host:rpc_port>/soroban/rpc}` \\ tests use this rpc instance and the container will not run a network internally, therefore ignores  `CoreDebianVersion`, `HorizonDebianVersion`,`SorobanRPCDebianVersion`, `TargetNetwork`  
+`--TargetNetworkPassphrase "{passphrase}"`  
+`--TargetNetworkTestAccountSecret "{your test account key pair info}"`  
+`--TargetNetworkTestAccountPublic "{your test account key pair info}"`  
 
 Debug mode, the docker container will exit with error code when any pre-setup or test fails to pass,
-you can enable DEBUG_MODE flag, and the container will stay running, prompting you for enter key before shutting down, make sure you invoke docker with `-it` so the prompt will reach your command line. While container is kept running, you can shell into it via `docker exec -it <container id or name>` and view log files of core, rpc, horizon all of which are located in container at `/var/log/supervisor`.
+you can enable DEBUG_MODE flag, and the container will stay running, prompting you for enter key before shutting down, make sure you invoke docker with `-it` so the prompt will reach your command line. While container is kept running, you can shell into it via `docker exec -it <container id or name>` and view log files of core, rpc, horizon all of which are located in container at `/var/log/supervisor`.  
 `--DebugMode=true`
 
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ or
 The ending wildcard allows for all combinations of example data for a scenario outline, without that it would just run the first example data set in a scenario outline.
 
 The default target network for system tests is a new/empty instance of standalone network hosted inside the docker container, tests will use the default root account already seeded into standalone network. Alternatively, can override the network settings here:  
-* Tests will use an internally hosted core node connected to standalone or futurenet network  
+* Tests will use an internally hosted core node connected to standalone or futurenet network:  
 `--TargetNetwork {standalone|futurenet}`  
-* Tests use this rpc instance and the container will not run a network internally, therefore ignores  `CoreDebianVersion`, `HorizonDebianVersion`,`SorobanRPCDebianVersion`, `TargetNetwork`  
+* Tests use this rpc instance and the container will not run a network internally, therefore ignores  `CoreDebianVersion`, `HorizonDebianVersion`,`SorobanRPCDebianVersion`, `TargetNetwork`:  
 `--TargetNetworkRPCURL {http://<rpc_host:rpc_port>/soroban/rpc}`  
-* Tests use these settings in either mode target network mode, and these are by default set to work with standalone
+* Tests use these settings in either target network mode, and these are by default set to work with standalone:  
 `--TargetNetworkPassphrase "{passphrase}"`  
 `--TargetNetworkTestAccountSecret "{your test account key pair info}"`  
 `--TargetNetworkTestAccountPublic "{your test account key pair info}"`  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 `docker build --platform linux/amd64 --no-cache -t stellar/system-test -f Dockerfile .`
 
 ### Run tests from the docker image:
-In short term, running tests on the `stellar/stellar-system-test` docker image is only supported on hosts that are on x86/amd cpu platforms. Arm cpu platforms are not supported for docker usage yet, this includes any Apple M1 device. If you are in the latter group, then can still run the tests but will need to refer to running tests directly from checked out repo instead.
+In short term, running tests on the `stellar/system-test` docker image is only supported on hosts that are on x86/amd cpu platforms. Arm cpu platforms are not supported for docker usage yet, this includes any Apple M1 device. If you are in the latter group, then can still run the tests but will need to refer to running tests directly from checked out repo instead.
 
 Running docker image, this is an example using real version numbers, please change these version values to versions you want to test:
 ```

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ or
 The ending wildcard allows for all combinations of example data for a scenario outline, without that it would just run the first example data set in a scenario outline.
 
 The default target network for system tests is a new/empty instance of standalone network hosted inside the docker container, tests will use the default root account already seeded into standalone network. Alternatively, can override the network settings here:  
-`--TargetNetwork {standalone|futurenet}` \\ sets the internally hosted network to either standalone or futurenet  
-`--TargetNetworkRPCURL {http://<rpc_host:rpc_port>/soroban/rpc}` \\ tests use this rpc instance and the container will not run a network internally, therefore ignores  `CoreDebianVersion`, `HorizonDebianVersion`,`SorobanRPCDebianVersion`, `TargetNetwork`  
+* Tests will use an internally hosted core node connected to standalone or futurenet network  
+`--TargetNetwork {standalone|futurenet}`  
+* Tests use this rpc instance and the container will not run a network internally, therefore ignores  `CoreDebianVersion`, `HorizonDebianVersion`,`SorobanRPCDebianVersion`, `TargetNetwork`  
+`--TargetNetworkRPCURL {http://<rpc_host:rpc_port>/soroban/rpc}`  
+* Tests use these settings in either mode target network mode, and these are by default set to work with standalone
 `--TargetNetworkPassphrase "{passphrase}"`  
 `--TargetNetworkTestAccountSecret "{your test account key pair info}"`  
 `--TargetNetworkTestAccountPublic "{your test account key pair info}"`  
@@ -73,9 +76,9 @@ This approach allows to run the tests directly on host as go tests. It allows to
 #### Running tests 
 ```
 system-test $ SorobanCLICrateVersion=0.2.1 \
- SorobanExamplesGitHash="main" \
+ SorobanExamplesGitHash="main" \\
  SorobanExamplesRepoURL="https://github.com/stellar/soroban-examples.git" \
- TargetNetworkPassPhrase="Standalone Network ; February 2017" \
+ TargetNetworkPassPhrase="Standalone Network ; February 2017" \\
  TargetNetworkSecretKey="SC5O7VZUXDJ6JBDSZ74DSERXL7W3Y5LTOAMRF7RQRL3TAGAPS7LUVG3L" \
  TargetNetworkPublicKey="GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI" \
  TargetNetworkRPCURL="http://localhost:8000/soroban/rpc" \

--- a/features/dapp_develop/dapp_develop_test.go
+++ b/features/dapp_develop/dapp_develop_test.go
@@ -126,6 +126,7 @@ func deployContract(ctx context.Context, compiledContractFileName string) error 
 
 	if testConfig.InstalledContractId != "" {
 		envCmd = cmd.NewCmd("soroban",
+			//		"contract",
 			"deploy",
 			"--wasm-hash", testConfig.InstalledContractId,
 			"--rpc-url", testConfig.E2EConfig.TargetNetworkRPCURL,
@@ -133,6 +134,7 @@ func deployContract(ctx context.Context, compiledContractFileName string) error 
 			"--network-passphrase", testConfig.E2EConfig.TargetNetworkPassPhrase)
 	} else {
 		envCmd = cmd.NewCmd("soroban",
+			//		"contract",
 			"deploy",
 			"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
 			"--rpc-url", testConfig.E2EConfig.TargetNetworkRPCURL,
@@ -160,6 +162,7 @@ func installContract(ctx context.Context, compiledContractFileName string) error
 	contractWorkingDirectory := fmt.Sprintf("%s/soroban_examples", testConfig.TestWorkingDir)
 
 	envCmd := cmd.NewCmd("soroban",
+		//	"contract",
 		"install",
 		"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
 		"--rpc-url", testConfig.E2EConfig.TargetNetworkRPCURL,
@@ -207,7 +210,11 @@ func invokeContract(ctx context.Context, functionName string, contractName strin
 
 func invokeContractFromCliTool(testConfig *testConfig, functionName string, contractName string, param1 string) (string, error) {
 
-	args := []string{"invoke", "--fn", functionName}
+	args := []string{
+		//             "contract",
+		"invoke",
+		"--fn",
+		functionName}
 
 	if param1 != "" {
 		args = append(args, "--arg")
@@ -255,7 +262,7 @@ func queryAccount(ctx context.Context) error {
             }
         }`)
 
-	resp, err := http.Post("http://localhost:8000/soroban/rpc", "application/json", bytes.NewBuffer(getAccountRequest))
+	resp, err := http.Post(testConfig.E2EConfig.TargetNetworkRPCURL, "application/json", bytes.NewBuffer(getAccountRequest))
 	if err != nil {
 		return fmt.Errorf("soroban rpc get account had error %e", err)
 	}

--- a/features/dapp_develop/dapp_develop_test.go
+++ b/features/dapp_develop/dapp_develop_test.go
@@ -126,7 +126,7 @@ func deployContract(ctx context.Context, compiledContractFileName string) error 
 
 	if testConfig.InstalledContractId != "" {
 		envCmd = cmd.NewCmd("soroban",
-			//		"contract",
+			"contract",
 			"deploy",
 			"--wasm-hash", testConfig.InstalledContractId,
 			"--rpc-url", testConfig.E2EConfig.TargetNetworkRPCURL,
@@ -134,7 +134,7 @@ func deployContract(ctx context.Context, compiledContractFileName string) error 
 			"--network-passphrase", testConfig.E2EConfig.TargetNetworkPassPhrase)
 	} else {
 		envCmd = cmd.NewCmd("soroban",
-			//		"contract",
+			"contract",
 			"deploy",
 			"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
 			"--rpc-url", testConfig.E2EConfig.TargetNetworkRPCURL,
@@ -162,7 +162,7 @@ func installContract(ctx context.Context, compiledContractFileName string) error
 	contractWorkingDirectory := fmt.Sprintf("%s/soroban_examples", testConfig.TestWorkingDir)
 
 	envCmd := cmd.NewCmd("soroban",
-		//	"contract",
+		"contract",
 		"install",
 		"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
 		"--rpc-url", testConfig.E2EConfig.TargetNetworkRPCURL,
@@ -211,7 +211,7 @@ func invokeContract(ctx context.Context, functionName string, contractName strin
 func invokeContractFromCliTool(testConfig *testConfig, functionName string, contractName string, param1 string) (string, error) {
 
 	args := []string{
-		//             "contract",
+		"contract",
 		"invoke",
 		"--fn",
 		functionName}

--- a/start
+++ b/start
@@ -18,11 +18,11 @@ CORE_DEBIAN_VERSION=
 HORIZON_DEBIAN_VERSION=
 SOROBAN_RPC_DEBIAN_VERSION=
 SOROBAN_RPC_SOURCE_VOLUME=
-TARGET_NETWORK=standalone
+TARGET_NETWORK=
 TARGET_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 TARGET_NETWORK_SECRET_KEY="SC5O7VZUXDJ6JBDSZ74DSERXL7W3Y5LTOAMRF7RQRL3TAGAPS7LUVG3L"
 TARGET_NETWORK_PUBLIC_KEY="GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI"
-TARGET_NETWORK_RPC_URL="http://localhost:8000/soroban/rpc"
+TARGET_NETWORK_RPC_URL=
 
 # example filter for all combos of one scenario outline: ^TestDappDevelop$/^DApp developer compiles, deploys and invokes a contract.*$
 # each row in example data for a scenario outline is postfixed with '#01', '#02', example:
@@ -51,60 +51,78 @@ function main() {
 
     process_args "$@"
 
-    if [ "$TARGET_NETWORK" != "standalone" ] && [ "$TARGET_NETWORK" != "futurenet" ]; then
+    if [ ! -z "$TARGET_NETWORK_RPC_URL" ] && [ ! -z "$TARGET_NETWORK" ]; then
+        echo "Invalid TargetNetwork config, must be TargetNetwork=standalone|futurenet or TargetNetworkRPCURL, aborting test ..."
+        exit 1
+    fi  
+
+    if [ -z "$TARGET_NETWORK_RPC_URL" ] && [ "$TARGET_NETWORK" != "standalone" ] && [ "$TARGET_NETWORK" != "futurenet" && ]; then
         echo "Invalid TargetNetwork, must be one of standalone or futurenet, aborting test ..."
         exit 1
     fi  
 
-    if [ "$RUN_TARGET_STACK_ONLY" != "true" ] && [ -z "$SOROBAN_CLI_CRATE_VERSION" ] && [ -z "$SOROBAN_CLI_SOURCE_VOLUME" ]; then
-        echo "Invalid CLI config, must provide SorobanCLICrateVersion or SorobanCLISourceVolume , aborting test ..."
+    if [ ! -z "$TARGET_NETWORK_RPC_URL" ] && [ "$RUN_TARGET_STACK_ONLY" = "true" ]; then
+        echo "Invalid Network config, must be TargetNetworkRPCURL or RunTargetStackOnly, aborting test ..."
         exit 1
-    fi 
-
-    if [ -z "$SOROBAN_RPC_DEBIAN_VERSION" ] && [ -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
-        echo "Invalid RPC config, must provide SorobanRPCDebianVersion or SorobanRPCSourceVolume , aborting test ..."
-        exit 1
-    fi 
-
-    if [ -z "$CORE_DEBIAN_VERSION" ]; then
-        echo "Invalid Core config, must provide CoreDebianVersion , aborting test ..."
-        exit 1
-    fi 
-
-    if [ -z "$HORIZON_DEBIAN_VERSION" ]; then
-        echo "Invalid Horizon config, must provide HorizonDebianVersion , aborting test ..."
-        exit 1
-    fi 
-
-    echo "running target stack with following config:"
-    echo "  CORE_DEBIAN_VERSION=$CORE_DEBIAN_VERSION"
-    echo "  HORIZON_DEBIAN_VERSION=$HORIZON_DEBIAN_VERSION"
-    if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
-        echo "  SOROBAN_RPC_SOURCE_VOLUME=$SOROBAN_RPC_SOURCE_VOLUME"
-    else
-        echo "  SOROBAN_RPC_DEBIAN_VERSION=$SOROBAN_RPC_DEBIAN_VERSION"
-    fi  
-     
-    echo "Installing Soroban stack ..."
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -qq >> /var/log/systemtest.log 2>&1
-    apt-get install -y -qq --allow-downgrades stellar-core=${CORE_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
-    echo "Installed core ..."
-    apt-get install -y -qq --allow-downgrades stellar-horizon=${HORIZON_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
-    echo "Installed horizon ..."
-    if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
-       pushd "$SOROBAN_RPC_SOURCE_VOLUME"
-       go build -v -trimpath -buildvcs=false -o usr/bin/stellar-soroban-rpc ./cmd/soroban-rpc
-       popd
-       echo "Compiled soroban rpc from source ... $(/usr/bin/stellar-soroban-rpc version)"
-    else
-       apt-get install -y -qq --allow-downgrades stellar-soroban-rpc=${SOROBAN_RPC_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
-       echo "Installed soroban rpc ..."
     fi  
 
-    /start --$TARGET_NETWORK --enable-soroban-rpc >> /var/log/systemtest.log 2>&1 &
-    validateSorobanRPC
-    echo "Started the Soroban stack on target network $TARGET_NETWORK ..." 
+    if [ -z "$TARGET_NETWORK_RPC_URL" ]; then
+
+        if [ "$RUN_TARGET_STACK_ONLY" != "true" ] && [ -z "$SOROBAN_CLI_CRATE_VERSION" ] && [ -z "$SOROBAN_CLI_SOURCE_VOLUME" ]; then
+            echo "Invalid CLI config, must provide SorobanCLICrateVersion or SorobanCLISourceVolume , aborting test ..."
+            exit 1
+        fi 
+
+        if [ -z "$SOROBAN_RPC_DEBIAN_VERSION" ] && [ -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
+            echo "Invalid RPC config, must provide SorobanRPCDebianVersion or SorobanRPCSourceVolume , aborting test ..."
+            exit 1
+        fi 
+
+        if [ -z "$CORE_DEBIAN_VERSION" ]; then
+            echo "Invalid Core config, must provide CoreDebianVersion , aborting test ..."
+            exit 1
+        fi 
+
+        if [ -z "$HORIZON_DEBIAN_VERSION" ]; then
+            echo "Invalid Horizon config, must provide HorizonDebianVersion , aborting test ..."
+            exit 1
+        fi 
+
+        TARGET_NETWORK_RPC_URL=http://localhost:8000/soroban/rpc
+
+        echo "running target stack with following config:"
+        echo "  CORE_DEBIAN_VERSION=$CORE_DEBIAN_VERSION"
+        echo "  HORIZON_DEBIAN_VERSION=$HORIZON_DEBIAN_VERSION"
+        if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
+            echo "  SOROBAN_RPC_SOURCE_VOLUME=$SOROBAN_RPC_SOURCE_VOLUME"
+        else
+            echo "  SOROBAN_RPC_DEBIAN_VERSION=$SOROBAN_RPC_DEBIAN_VERSION"
+        fi  
+         
+        echo "Installing Soroban stack ..."
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq >> /var/log/systemtest.log 2>&1
+        apt-get install -y -qq --allow-downgrades stellar-core=${CORE_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
+        echo "Installed core ..."
+        apt-get install -y -qq --allow-downgrades stellar-horizon=${HORIZON_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
+        echo "Installed horizon ..."
+        if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
+            pushd "$SOROBAN_RPC_SOURCE_VOLUME"
+            go build -v -trimpath -buildvcs=false -o usr/bin/stellar-soroban-rpc ./cmd/soroban-rpc
+            popd
+            echo "Compiled soroban rpc from source ... $(/usr/bin/stellar-soroban-rpc version)"
+        else
+            apt-get install -y -qq --allow-downgrades stellar-soroban-rpc=${SOROBAN_RPC_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
+            echo "Installed soroban rpc ..."
+        fi  
+
+        /start --$TARGET_NETWORK --enable-soroban-rpc >> /var/log/systemtest.log 2>&1 &
+        validateSorobanRPC
+        validateHorizon
+        echo "Started the Soroban stack on target network $TARGET_NETWORK ..." 
+    else
+        validateSorobanRPC     
+    fi
     
     apt-get clean -qq >> /var/log/systemtest.log 2>&1
     
@@ -242,10 +260,18 @@ function process_args() {
       --TargetNetworkTestAccountPublic) 
         TARGET_NETWORK_PUBLIC_KEY="$1"
         shift
-        ;;             
+        ;;       
+      --TargetNetworkRPCURL) 
+        TARGET_NETWORK_RPC_URL="$1"
+        shift
+        ;;            
       *)
       esac
     done
+
+    if [ -z "$TARGET_NETWORK_RPC_URL" ] && [ -z "$TARGET_NETWORK" ]; then
+        TARGET_NETWORK=standalone
+    fi 
 }
 
 function validateHorizon () {
@@ -264,7 +290,7 @@ function validateHorizon () {
 
 function validateSorobanRPC () {
     COUNTER=1
-    while ! (curl --silent --location --request POST 'http://localhost:8000/soroban/rpc' \
+    while ! (curl --silent --location --request POST "$TARGET_NETWORK_RPC_URL" \
                 --header 'Content-Type: application/json' \
         --data-raw '{
           "jsonrpc": "2.0",
@@ -281,9 +307,6 @@ function validateSorobanRPC () {
       COUNTER=$[$COUNTER +1]
     done 
     echo "Soroban rpc is running ..."
-
-    validateHorizon
-
 }
 
 main "$@"

--- a/start
+++ b/start
@@ -276,7 +276,7 @@ function process_args() {
 
 function validateHorizon () {
     COUNTER=1
-    while ! (curl --silent --location --request GET 'http://localhost:8000' | jq --exit-status '.history_latest_ledger > 0'); do
+    while ! (curl --silent --location --request GET 'http://localhost:8000' | jq --exit-status '.history_latest_ledger > 0' > /dev/null 2>&1 ); do
       if [ $COUNTER -gt 24 ]; then 
           echo "Horizon ingestion did not become available in 2 minutes, aborting test ..."
           exit 1
@@ -297,7 +297,7 @@ function validateSorobanRPC () {
           "id": 10235,
           "method": "getHealth"
           
-        }' | jq --exit-status '.result.status == "healthy"'); do
+        }' | jq --exit-status '.result.status == "healthy"' > /dev/null 2>&1 ); do
       if [ $COUNTER -gt 24 ]; then 
           echo "Soroban rpc did not become available in 2 minutes, aborting test ..."
           exit 1


### PR DESCRIPTION
* Change feature tests to invoke the new `contract` subcommand format in soroban cli - https://github.com/stellar/soroban-tools/pull/319

* corrected typos in README

* Included small change to include `--TargetNetworkRPCURL` as optional test parameter on docker image invocation.

Closes #12 