### PR TITLE
Fix SorobanRPCSourceVolume output directory

### DIFF
--- a/start
+++ b/start
@@ -108,7 +108,7 @@ function main() {
         echo "Installed horizon ..."
         if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
             pushd "$SOROBAN_RPC_SOURCE_VOLUME"
-            go build -v -trimpath -buildvcs=false -o usr/bin/stellar-soroban-rpc ./cmd/soroban-rpc
+            go build -v -trimpath -buildvcs=false -o /usr/bin/stellar-soroban-rpc ./cmd/soroban-rpc
             popd
             echo "Compiled soroban rpc from source ... $(/usr/bin/stellar-soroban-rpc version)"
         else


### PR DESCRIPTION
when using `--SorobanRPCSourceVolume`, the compiled rpc bin was not being copied to correct path location on docker image, this fixes that, so that the compiled bin is the one actually run by container.