### PR TITLE
Mark soroban-rpc volume as a safe git directory

### DIFF
--- a/start
+++ b/start
@@ -113,6 +113,7 @@ function main() {
         echo "Installed horizon ..."
         if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
             pushd "$SOROBAN_RPC_SOURCE_VOLUME"
+            git config --global --add safe.directory "$SOROBAN_RPC_SOURCE_VOLUME"
             make build-soroban-rpc
             mv soroban-rpc /usr/bin/
             popd

--- a/start
+++ b/start
@@ -115,7 +115,7 @@ function main() {
             pushd "$SOROBAN_RPC_SOURCE_VOLUME"
             git config --global --add safe.directory "$SOROBAN_RPC_SOURCE_VOLUME"
             make build-soroban-rpc
-            mv soroban-rpc /usr/bin/
+            mv soroban-rpc /usr/bin/stellar-soroban-rpc
             popd
             echo "Compiled soroban rpc from source ... $(/usr/bin/stellar-soroban-rpc version)"
         else


### PR DESCRIPTION
Followup to #18 

Otherwise compilation fails with:

```
fatal: detected dubious ownership in repository at '/soroban-tools'
To add an exception for this directory, call:

	git config --global --add safe.directory /soroban-tools
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
make: *** [Makefile:65: build-soroban-rpc] Error 1
```

See https://github.com/stellar/soroban-tools/actions/runs/4043611791/jobs/6952740592

