### PR TITLE
Support captive core usage with Soroban RPC

### DIFF
--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository,  github.event.ref || 'latest') }}
-  CORE_GIT_REF: main
+  CORE_GIT_REF: master
   CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
   SOROBAN_RPC_GIT_REF: main
   RUST_TOOLCHAIN_VERSION: stable
@@ -59,10 +59,10 @@ jobs:
         path: /tmp/image
 
   push:
-    # Only push pre-built system test image that has all versions compiled into image, that's what tags have.
+    # Only push non 'vX.Y.Z' tags as pre-built system test image with versions compiled into image.
     # pr's and releases don't need to be pushed as docker images, because system test is meant to be built 
-    # from source, Makefile.
-    if: (github.event_name == 'create' && github.event.ref_type == 'tag')
+    # from source locally.
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, ‘v’) != true)
     needs: build
     permissions:
       packages: write

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository,  github.event.ref || 'latest') }}
-  CORE_GIT_REF: f1dc39f0f146815e5e3a94ed162e2f0639cb433f
+  CORE_GIT_REF: main
   CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
   SOROBAN_RPC_GIT_REF: main
   RUST_TOOLCHAIN_VERSION: stable

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -62,7 +62,7 @@ jobs:
     # Only push non 'vX.Y.Z' tags as pre-built system test image with versions compiled into image.
     # pr's and releases don't need to be pushed as docker images, because system test is meant to be built 
     # from source locally.
-    if: (github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, ‘v’) != true)
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v') != true)
     needs: build
     permissions:
       packages: write

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -19,6 +19,12 @@ concurrency:
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event.release.name || 'latest') }}
+  CORE_GIT_REF: f1dc39f0f146815e5e3a94ed162e2f0639cb433f
+  CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
+  SOROBAN_RPC_GIT_REF: main
+  RUST_TOOLCHAIN_VERSION: stable
+  SOROBAN_CLI_GIT_REF: main
+  QUICKSTART_GIT_REF: master
 jobs:
   complete:
     if: always()
@@ -36,7 +42,14 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build System Test Image
-      run: docker buildx build --no-cache -f Dockerfile -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image .
+      run: |
+        make CORE_GIT_REF=${{ env.CORE_GIT_REF }} \
+             CORE_COMPILE_CONFIGURE_FLAGS="${{ env.CORE_COMPILE_CONFIGURE_FLAGS }}" \
+             SOROBAN_RPC_GIT_REF=${{ env.SOROBAN_RPC_GIT_REF }} \
+             RUST_TOOLCHAIN_VERSION=${{ env.RUST_TOOLCHAIN_VERSION }} \
+             SOROBAN_CLI_GIT_REF=${{ env.SOROBAN_CLI_GIT_REF }} \
+             QUICKSTART_GIT_REF=${{ env.QUICKSTART_GIT_REF }} build;
+        docker save stellar/quickstart:dev -o /tmp/image;
     - name: Upload System Test Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  create:
+    tags:      
   pull_request:
   release:
     types: [published]
@@ -18,7 +20,7 @@ concurrency:
 
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event.release.name || 'latest') }}
+  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository,  github.event.ref || 'latest') }}
   CORE_GIT_REF: f1dc39f0f146815e5e3a94ed162e2f0639cb433f
   CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
   SOROBAN_RPC_GIT_REF: main
@@ -57,8 +59,10 @@ jobs:
         path: /tmp/image
 
   push:
-    # Push image to registry after build under certain cases
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'master') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Only push pre-built system test image that has all versions compiled into image, that's what tags have.
+    # pr's and releases don't need to be pushed as docker images, because system test is meant to be built 
+    # from source, Makefile.
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag')
     needs: build
     permissions:
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test_tmp_workspace/
 systest.sublime-project
 systest.sublime-workspace
+.quickstart_repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# System Test Releases
+
+
+
+#### 1.0.2
+
+* Modified tests to follow the new dynamic args format on cli [soroban-tools, #307](https://github.com/stellar/soroban-tools/pull/307)
+
+This version of tests is based on [Soroban Preview 6](https://soroban.stellar.org/docs/releases#preview-6-january-9th-2023) system interfaces, combined with the additional change applied on top of dynamic args in cli `contract invoke` 
+
+
+#### 1.0.1
+
+* Modified tests to follow the new `contract` sub-command on cli [soroban-tools, #319](https://github.com/stellar/soroban-tools/pull/319)
+
+This version of tests executes the [Soroban Preview 6](https://soroban.stellar.org/docs/releases#preview-6-january-9th-2023) system interfaces only.
+
+
+#### 1.0.0
+First release of packaged system tests. Initial focus is on Soroban e2e cases using cli,rpc,core:
+
+* DApp developer compiles, installs, deploys and invokes a contract
+* DApp developer compiles, deploys and invokes a contract
+
+This version of tests execute the [Soroban Preview 5](https://soroban.stellar.org/docs/releases#preview-5-december-8th-2022) system interfaces only.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM golang:1.19 as go
 RUN ["mkdir", "-p", "/test"] 
 RUN ["mkdir", "-p", "/test/bin"] 
 
-ADD go.mod go.sum /test
 WORKDIR /test
+ADD go.mod go.sum .
+
 RUN go mod download
 ADD e2e.go ./ features ./
 # specify each feature folder with go test module, 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN ["mkdir", "-p", "/test"]
 RUN ["mkdir", "-p", "/test/bin"] 
 
 WORKDIR /test
-ADD go.mod go.sum .
-
+ADD go.mod go.sum e2e.go ./
+ADD features ./features
 RUN go mod download
-ADD e2e.go ./ features ./
-# specify each feature folder with go test module, 
+
+# build each feature folder with go test module.
 # compiles each feature to a binary to be executed, 
 # and copies the .feature file with it for runtime.
 RUN go test -c -o ./bin/dapp_develop_test ./features/dapp_develop/...
@@ -37,7 +37,6 @@ FROM base as build
 RUN ["mkdir", "-p", "/opt/test"] 
 ADD start /opt/test
 COPY --from=go /test/bin/ /opt/test/bin
-COPY --from=go /usr/local/go/ /usr/local/go/
 
 RUN ["chmod", "+x", "/opt/test/start"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.EXPORT_ALL_VARIABLES:
+.SILENT:
+
+SYSTEM_TEST_IMAGE?=stellar/system-test:dev
+SYSTEM_TEST_SHA=$(shell git rev-parse HEAD)
+ENABLE_PUSH?=false
+
+CORE_GIT_REF=
+CORE_COMPILE_CONFIGURE_FLAGS?=--disable-tests --enable-next-protocol-version-unsafe-for-production
+SOROBAN_RPC_GIT_REF=main
+
+RUST_TOOLCHAIN_VERSION?=stable
+SOROBAN_CLI_CRATE_VERSION=
+SOROBAN_CLI_GIT_REF=main
+
+QUICKSTART_IMAGE=
+QUICKSTART_GIT_REF=master
+QUICKSTART_GIT_REPO?=https://github.com/stellar/quickstart.git
+
+.PHONY: build build-base
+
+build-base: 	
+	if [ -z "$(QUICKSTART_IMAGE)" ]; then \
+	  set -e ;\
+	  rm -rf .quickstart_repo; \
+      git clone -q $(QUICKSTART_GIT_REPO) .quickstart_repo; \
+      pushd .quickstart_repo; \
+      git checkout "$(QUICKSTART_GIT_REF)"; \
+      $(MAKE) CORE_REF=$(CORE_GIT_REF) \
+           CORE_CONFIGURE_FLAGS="$(CORE_COMPILE_CONFIGURE_FLAGS)" \
+           SOROBAN_TOOLS_REF=$(SOROBAN_RPC_GIT_REF); \
+    fi
+
+build: build-base
+	QUICKSTART_IMAGE=$$( [ -z "$(QUICKSTART_IMAGE)" ] && echo "stellar/quickstart:dev" || echo "$(QUICKSTART_IMAGE)"); \
+    docker build -t "$(SYSTEM_TEST_IMAGE)" \
+      -f Dockerfile \
+      --build-arg QUICKSTART_IMAGE_REF="$$QUICKSTART_IMAGE" \
+      --build-arg SOROBAN_CLI_CRATE_VERSION="$(SOROBAN_CLI_CRATE_VERSION)" \
+      --build-arg SOROBAN_CLI_GIT_REF=$(SOROBAN_CLI_GIT_REF) \
+      --build-arg RUST_TOOLCHAIN_VERSION=$(RUST_TOOLCHAIN_VERSION) \
+      --label org.opencontainers.image.revision="$(SYSTEM_TEST_SHA)" .
+	

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 .EXPORT_ALL_VARIABLES:
 .SILENT:
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-base:
 	  rm -rf .quickstart_repo; \
       git clone -q $(QUICKSTART_GIT_REPO) .quickstart_repo; \
       pushd .quickstart_repo; \
-      git checkout "$(QUICKSTART_GIT_REF)"; \
+      git fetch origin "$(QUICKSTART_GIT_REF)" && git checkout FETCH_HEAD; \
       $(MAKE) CORE_REF=$(CORE_GIT_REF) \
            CORE_CONFIGURE_FLAGS="$(CORE_COMPILE_CONFIGURE_FLAGS)" \
            SOROBAN_TOOLS_REF=$(SOROBAN_RPC_GIT_REF); \

--- a/README.md
+++ b/README.md
@@ -96,19 +96,20 @@ you can enable DEBUG_MODE flag, and the container will stay running, prompting y
 The docker run follows standard exit code conventions, so if all tests pass in the container run, exit code from command line execution will be 0, otherwise, if any failures in container or tests, then exit code will be greater than 0.
 
 
-### Run tests from locally checked out system-test repo.
-This approach allows to run the tests directly on host as go tests, no docker image. It allows to configure more aspects directly, like target network to use, and whether to try to use pre-existing cli on the host if desired but does require more environment setup.
+### Development mode and running tests directly from checked out system-test repo.
+This approach allows to run the tests from source code directly on host as go tests, no docker image.  
+Tests will use `soroban` cli tool from the host path. You need to set `TargetNetworkRPCURL` to a running instance of soroban rpc.
 
 #### Prerequisites:
 
  1. go 1.18 or above - https://go.dev/doc/install
  2. rust toolchain(cargo and rustc), install the version per testing requirements or stable, - use rustup - https://www.rust-lang.org/tools/install 
- 3. target network stack for the tests to execute against - need a soroban-rpc instance. You can use an existing/running instance if reachable or can use the quickstart image `stellar/quickstart:soroban-dev` to run the latest stable target network stack locally, or build quickstart with specific versions of core, horizon and soroban rpc first [following these instructions](https://github.com/stellar/quickstart#building-custom-images) and run quickstart locally.
+ 3. target network stack for the tests to execute against - need a soroban-rpc instance. You can use an existing/running instance if reachable or can use the quickstart image `stellar/quickstart:soroban-dev` from dockerhub to run the latest stable target network stack locally, or build quickstart with specific versions of core, horizon and soroban rpc first [following these instructions](https://github.com/stellar/quickstart#building-custom-images) and run `stellar/quickstart:dev` locally.
      ```
      docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:dev --standalone --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing
      ```
  4. locally checkout stellar/system-test GH repo and go into top folder - `git clone https://github.com/stellar/system-test.git;cd system-test`
- 5. compile or install vai cargo create a version of soroban cli onto your machine and accessible from PATH.
+ 5. compile or install via cargo crate a version of soroban cli onto your machine and accessible from PATH.
 
 #### Running tests 
 ```

--- a/e2e.go
+++ b/e2e.go
@@ -10,9 +10,6 @@ import (
 
 type E2EConfig struct {
 	// e2e settings
-	SorobanCLISourceVolume    string
-	SorobanCLICrateVersion    string
-	SorobanJSClientNpmVersion string
 	SorobanExamplesGitHash    string
 	SorobanExamplesRepoURL    string
 	VerboseOutput             bool
@@ -29,12 +26,6 @@ const TestTmpDirectory = "test_tmp_workspace"
 func InitEnvironment() (*E2EConfig, error) {
 	var flagConfig = &E2EConfig{}
 	var err error
-
-	flagConfig.SorobanCLICrateVersion, _ = getEnv("SorobanCLICrateVersion")
-	flagConfig.SorobanCLISourceVolume, _ = getEnv("SorobanCLISourceVolume")
-
-	//TODO - enable this when JS Client test steps are supported.
-	flagConfig.SorobanJSClientNpmVersion, _ = getEnv("SorobanJSClientNpmVersion")
 
 	if flagConfig.SorobanExamplesGitHash, err = getEnv("SorobanExamplesGitHash"); err != nil {
 		return nil, err
@@ -113,45 +104,6 @@ func RunCommand(testCmd *cmd.Cmd, config *E2EConfig) (int, []string, error) {
 	<-doneChan
 
 	return envCmd.Status().Exit, output, envCmd.Status().Error
-}
-
-func InstallCli(fc *E2EConfig) error {
-
-	var installCliCmd *cmd.Cmd
-	if fc.SorobanCLISourceVolume != "" {
-		installCliCmd = cmd.NewCmd("cargo",
-			"install",
-			"--config", "net.git-fetch-with-cli=true",
-			"--config", "build.jobs=6",
-			"-f",
-			"--path", "./cmd/soroban-cli")
-		installCliCmd.Dir = fc.SorobanCLISourceVolume
-	} else if fc.SorobanCLICrateVersion == "" {
-		envCmd := cmd.NewCmd("soroban", "version")
-
-		status, versionOutput, err := RunCommand(envCmd, fc)
-
-		if status != 0 || err != nil {
-			return fmt.Errorf("no soroban cli present, SorobanCLICrateVersion was not specified, and not able to run soroban from current path, %d, %e", status, err)
-		}
-		fmt.Printf("SorobanCLICrateVersion was not specified, will use version already present on path:\n %v \n\n", versionOutput)
-		return nil
-	} else {
-		installCliCmd = cmd.NewCmd("cargo",
-			"install",
-			"--config", "net.git-fetch-with-cli=true",
-			"--config", "build.jobs=6",
-			"-f", "--locked", "soroban-cli",
-			"--version", fc.SorobanCLICrateVersion)
-	}
-
-	status, _, err := RunCommand(installCliCmd, fc)
-
-	if status != 0 || err != nil {
-		return fmt.Errorf("cargo install of soroban cli had status %v and error %v", status, err)
-	}
-
-	return nil
 }
 
 // asserter is used to be able to retrieve the error reported by the called assertion

--- a/features/dapp_develop/dapp_develop_test.go
+++ b/features/dapp_develop/dapp_develop_test.go
@@ -59,13 +59,6 @@ func TestDappDevelop(t *testing.T) {
 	}
 	godog.BindCommandLineFlags("godog.", opts)
 
-	err = e2e.InstallCli(e2eConfig)
-
-	if err != nil {
-		fmt.Printf("Failed to install CLI version %s, error: %v \n\n", e2eConfig.SorobanCLICrateVersion, err)
-		os.Exit(1)
-	}
-
 	status := godog.TestSuite{
 		Name:                "soroban dapp e2e",
 		Options:             opts,

--- a/install
+++ b/install
@@ -6,4 +6,14 @@ apt-get update
 apt-get install -y build-essential
 apt-get clean
 
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.66.0
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN_VERSION"
+
+if [ ! -z "$SOROBAN_CLI_CRATE_VERSION" ]; then 
+  cargo install --config net.git-fetch-with-cli=true --config build.jobs=6 -f --locked soroban-cli --version "$SOROBAN_CLI_SOURCE_FOLDER"
+else 
+  git clone -q https://github.com/stellar/soroban-tools.git
+  pushd soroban-tools
+  git checkout "$SOROBAN_CLI_GIT_REF"
+  cargo install --config net.git-fetch-with-cli=true --config build.jobs=6 -f --path ./cmd/soroban-cli
+  popd
+fi		

--- a/start
+++ b/start
@@ -2,311 +2,211 @@
 set -e
 set -o pipefail
 
-echo "Starting system test ..." > /var/log/systemtest.log
-
 # the versions of software that tests will use
-RUST_TOOLCHAIN_DEFAULT_INSTALLED_VERSION=1.65.0
-RUST_TOOLCHAIN_VERSION=
-SOROBAN_CLI_CRATE_VERSION=
-SOROBAN_CLI_SOURCE_VOLUME=
 SOROBAN_EXAMPLES_GIT_HASH="main"
 SOROBAN_EXAMPLES_REPO_URL="https://github.com/stellar/soroban-examples.git"
 DEBUG_MODE=
 
 # the target network under test
-CORE_DEBIAN_VERSION=
-HORIZON_DEBIAN_VERSION=
-SOROBAN_RPC_DEBIAN_VERSION=
-SOROBAN_RPC_SOURCE_VOLUME=
 TARGET_NETWORK=
 TARGET_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 TARGET_NETWORK_SECRET_KEY="SC5O7VZUXDJ6JBDSZ74DSERXL7W3Y5LTOAMRF7RQRL3TAGAPS7LUVG3L"
 TARGET_NETWORK_PUBLIC_KEY="GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI"
 TARGET_NETWORK_RPC_URL=
+LOG_FILE=/var/log/system-test.log
 
 # example filter for all combos of one scenario outline: ^TestDappDevelop$/^DApp developer compiles, deploys and invokes a contract.*$
 # each row in example data for a scenario outline is postfixed with '#01', '#02', example:
 # TestDappDevelop/DApp developer compiles, deploys and invokes a contract#01
 TEST_FILTER=""
 VERBOSE_OUTPUT=false
-RUN_TARGET_STACK_ONLY=false
 CANCELLED=false
+
+function print_screen_output() {
+  echo "$1" | tee -a $LOG_FILE
+}
+
+print_screen_output "Starting system test ..." 
 
 trap printout SIGINT
 printout() {
-   echo "Cancelling and exit."
-   exit
+  echo "Cancelling and exit."
+  exit
 }
 
 trap finish EXIT
 function finish {
+  if [ $? -ne 0 ]; then
+    echo "" >&2
+    echo "" >&2
+    echo "dumping $LOG_FILE ..." >&2
+    echo "" >&2
+    echo "" >&2
+    cat $LOG_FILE >&2
+  fi  
   CANCELLED=true
   if [ "$DEBUG_MODE" = "true" ]; then
-      echo "** DEBUG MODE Enabled **"
+      print_screen_output "** DEBUG MODE Enabled **"
       read -p 'Debug mode, you can shell into the container now, hit enter to let container stop: ' 
   fi  
 }
 
 function main() {
+  process_args "$@"
 
-    process_args "$@"
+  if [ ! -z "$TARGET_NETWORK_RPC_URL" ] && [ ! -z "$TARGET_NETWORK" ]; then
+      echo "Invalid TargetNetwork config, must be TargetNetwork=standalone|futurenet or TargetNetworkRPCURL, aborting test ..." >&2
+      exit 1
+  fi  
 
-    if [ ! -z "$TARGET_NETWORK_RPC_URL" ] && [ ! -z "$TARGET_NETWORK" ]; then
-        echo "Invalid TargetNetwork config, must be TargetNetwork=standalone|futurenet or TargetNetworkRPCURL, aborting test ..."
-        exit 1
-    fi  
+  if [ -z "$TARGET_NETWORK_RPC_URL" ] && [ "$TARGET_NETWORK" != "standalone" ] && [ "$TARGET_NETWORK" != "futurenet" && ]; then
+      echo "Invalid TargetNetwork, must be one of standalone or futurenet, aborting test ..." >&2
+      exit 1
+  fi  
 
-    if [ -z "$TARGET_NETWORK_RPC_URL" ] && [ "$TARGET_NETWORK" != "standalone" ] && [ "$TARGET_NETWORK" != "futurenet" && ]; then
-        echo "Invalid TargetNetwork, must be one of standalone or futurenet, aborting test ..."
-        exit 1
-    fi  
+  if [ -z "$TARGET_NETWORK_RPC_URL" ]; then
 
-    if [ ! -z "$TARGET_NETWORK_RPC_URL" ] && [ "$RUN_TARGET_STACK_ONLY" = "true" ]; then
-        echo "Invalid Network config, must be TargetNetworkRPCURL or RunTargetStackOnly, aborting test ..."
-        exit 1
-    fi  
+    TARGET_NETWORK_RPC_URL=http://localhost:8000/soroban/rpc
 
-    if [ -z "$TARGET_NETWORK_RPC_URL" ]; then
+    print_screen_output "starting target stack on $TARGET_NETWORK with following server versions:"
+    print_screen_output "  CORE VERSION=$(stellar-core version 2>/dev/null || echo "n/a")"
+    print_screen_output "  HORIZON VERSION=$(stellar-horizon version 2>/dev/null || echo "n/a")"
+    print_screen_output "  SOROBAN RPC VERSION=$(stellar-soroban-rpc version 2>/dev/null || echo "n/a")"
+      
+    /start --$TARGET_NETWORK --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing --logs >> $LOG_FILE 2>&1 &
+    horizon_status
+    soroban_rpc_status 
+  else
+    soroban_rpc_status     
+  fi
+  
+  print_screen_output "  RUST_TOOLCHAIN_VERSION=$(rustc --version 2>/dev/null || echo"n/a" )"
+  print_screen_output "  SOROBAN_CLI_CRATE_VERSION=$(soroban version 2>/dev/null || echo "n/a" )"
+  print_screen_output "  SOROBAN_EXAMPLES_GIT_HASH=$SOROBAN_EXAMPLES_GIT_HASH"
+  print_screen_output "  SOROBAN_EXAMPLES_REPO_URL=$SOROBAN_EXAMPLES_REPO_URL"
+  print_screen_output "  TARGET_NETWORK=$TARGET_NETWORK"
+  print_screen_output "  TARGET_NETWORK_PASSPHRASE=$TARGET_NETWORK_PASSPHRASE"
+  print_screen_output "  TARGET_NETWORK_SECRET_KEY=$TARGET_NETWORK_SECRET_KEY"
+  print_screen_output "  TARGET_NETWORK_PUBLIC_KEY=$TARGET_NETWORK_PUBLIC_KEY"
+  print_screen_output "  TARGET_NETWORK_RPC_URL=$TARGET_NETWORK_RPC_URL"
+  print_screen_output "  TEST_FILTER=${TEST_FILTER}"
+  print_screen_output "Tests can now begin ..." 
 
-        if [ "$RUN_TARGET_STACK_ONLY" != "true" ] && [ -z "$SOROBAN_CLI_CRATE_VERSION" ] && [ -z "$SOROBAN_CLI_SOURCE_VOLUME" ]; then
-            echo "Invalid CLI config, must provide SorobanCLICrateVersion or SorobanCLISourceVolume , aborting test ..."
-            exit 1
-        fi 
+  cd /opt/test/bin
 
-        if [ -z "$SOROBAN_RPC_DEBIAN_VERSION" ] && [ -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
-            echo "Invalid RPC config, must provide SorobanRPCDebianVersion or SorobanRPCSourceVolume , aborting test ..."
-            exit 1
-        fi 
+  export SorobanExamplesGitHash=${SOROBAN_EXAMPLES_GIT_HASH}
+  export SorobanExamplesRepoURL=${SOROBAN_EXAMPLES_REPO_URL}
+  export TargetNetworkPassPhrase="${TARGET_NETWORK_PASSPHRASE}"
+  export TargetNetworkSecretKey=${TARGET_NETWORK_SECRET_KEY}
+  export TargetNetworkPublicKey=${TARGET_NETWORK_PUBLIC_KEY}
+  export TargetNetworkRPCURL=${TARGET_NETWORK_RPC_URL}
+  export VerboseOutput=${VERBOSE_OUTPUT}
 
-        if [ -z "$CORE_DEBIAN_VERSION" ]; then
-            echo "Invalid Core config, must provide CoreDebianVersion , aborting test ..."
-            exit 1
-        fi 
-
-        if [ -z "$HORIZON_DEBIAN_VERSION" ]; then
-            echo "Invalid Horizon config, must provide HorizonDebianVersion , aborting test ..."
-            exit 1
-        fi 
-
-        TARGET_NETWORK_RPC_URL=http://localhost:8000/soroban/rpc
-
-        echo "running target stack with following config:"
-        echo "  CORE_DEBIAN_VERSION=$CORE_DEBIAN_VERSION"
-        echo "  HORIZON_DEBIAN_VERSION=$HORIZON_DEBIAN_VERSION"
-        if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
-            echo "  SOROBAN_RPC_SOURCE_VOLUME=$SOROBAN_RPC_SOURCE_VOLUME"
-        else
-            echo "  SOROBAN_RPC_DEBIAN_VERSION=$SOROBAN_RPC_DEBIAN_VERSION"
-        fi  
-         
-        echo "Installing Soroban stack ..."
-        export DEBIAN_FRONTEND=noninteractive
-        apt-get update -qq >> /var/log/systemtest.log 2>&1
-        apt-get install -y -qq --allow-downgrades stellar-core=${CORE_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
-        echo "Installed core ..."
-        apt-get install -y -qq --allow-downgrades stellar-horizon=${HORIZON_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
-        echo "Installed horizon ..."
-        if [ ! -z "$SOROBAN_RPC_SOURCE_VOLUME" ]; then
-            pushd "$SOROBAN_RPC_SOURCE_VOLUME"
-            go build -v -trimpath -buildvcs=false -o /usr/bin/stellar-soroban-rpc ./cmd/soroban-rpc
-            popd
-            echo "Compiled soroban rpc from source ... $(/usr/bin/stellar-soroban-rpc version)"
-        else
-            apt-get install -y -qq --allow-downgrades stellar-soroban-rpc=${SOROBAN_RPC_DEBIAN_VERSION} >> /var/log/systemtest.log 2>&1
-            echo "Installed soroban rpc ..."
-        fi  
-
-        /start --$TARGET_NETWORK --enable-soroban-rpc >> /var/log/systemtest.log 2>&1 &
-        validateSorobanRPC
-        validateHorizon
-        echo "Started the Soroban stack on target network $TARGET_NETWORK ..." 
-    else
-        validateSorobanRPC     
+  for file in ./*; 
+  do 
+    if [ "$CANCELLED" = "true" ]; then
+        break
     fi
-    
-    apt-get clean -qq >> /var/log/systemtest.log 2>&1
-    
-    echo "Tests can now begin ..."
-    if [ "$RUN_TARGET_STACK_ONLY" = "true" ]; then  
-        while [ "$CANCELLED" != "true" ];
-        do 
-          sleep 10 
-        done
-        return
+
+    if [[ "$file" =~ ^.*\.feature$ ]]; then 
+        continue
     fi  
-
-    echo "  RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION:-$(rustc --version 2>/dev/null )}"
-    if [ ! -z "$SOROBAN_CLI_SOURCE_VOLUME" ];  then
-        echo "  SOROBAN_CLI_SOURCE_VOLUME=${SOROBAN_CLI_SOURCE_VOLUME:-none}"
-    else 
-        echo "  SOROBAN_CLI_CRATE_VERSION=${SOROBAN_CLI_CRATE_VERSION:-$(soroban version 2>/dev/null )}"
-    fi  
-    echo "  SOROBAN_EXAMPLES_GIT_HASH=$SOROBAN_EXAMPLES_GIT_HASH"
-    echo "  SOROBAN_EXAMPLES_REPO_URL=$SOROBAN_EXAMPLES_REPO_URL"
-    echo "  TARGET_NETWORK=$TARGET_NETWORK"
-    echo "  TARGET_NETWORK_PASSPHRASE=$TARGET_NETWORK_PASSPHRASE"
-    echo "  TARGET_NETWORK_SECRET_KEY=$TARGET_NETWORK_SECRET_KEY"
-    echo "  TARGET_NETWORK_PUBLIC_KEY=$TARGET_NETWORK_PUBLIC_KEY"
-    echo "  TARGET_NETWORK_RPC_URL=$TARGET_NETWORK_RPC_URL"
-    echo "  TEST_FILTER=${TEST_FILTER}"
-
-    if [ ! -z "$RUST_TOOLCHAIN_VERSION" ] && [ "$RUST_TOOLCHAIN_VERSION" != "$RUST_TOOLCHAIN_DEFAULT_INSTALLED_VERSION" ]; then 
-      echo "Installing rust toolchain $RUST_TOOLCHAIN_VERSION ..."
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${RUST_TOOLCHAIN_VERSION}" 
-    fi 
-
-    cd /opt/test/bin
-
-    export SorobanCLICrateVersion=${SOROBAN_CLI_CRATE_VERSION}
-    export SorobanCLISourceVolume=${SOROBAN_CLI_SOURCE_VOLUME}
-    export SorobanExamplesGitHash=${SOROBAN_EXAMPLES_GIT_HASH}
-    export SorobanExamplesRepoURL=${SOROBAN_EXAMPLES_REPO_URL}
-    export TargetNetworkPassPhrase="${TARGET_NETWORK_PASSPHRASE}"
-    export TargetNetworkSecretKey=${TARGET_NETWORK_SECRET_KEY}
-    export TargetNetworkPublicKey=${TARGET_NETWORK_PUBLIC_KEY}
-    export TargetNetworkRPCURL=${TARGET_NETWORK_RPC_URL}
-    export VerboseOutput=${VERBOSE_OUTPUT}
-
-    for file in ./*; 
-    do 
-      if [ "$CANCELLED" = "true" ]; then
-          break
-      fi
-
-      if [[ "$file" =~ ^.*\.feature$ ]]; then 
-          continue
-      fi  
-      # these bin files were compiled from go feature tests in the Dockerfile during image build
-      echo "Running test binary ${file} ... "
-      ${file} -test.v ${TEST_FILTER};
-    done 
-    
+    # these bin files were compiled from go feature tests in the Dockerfile during image build
+    print_screen_output "Running test binary ${file} ... "  
+    ${file} -test.v ${TEST_FILTER} 2>&1 | tee -a $LOG_FILE 
+  done 
 }
 
 function process_args() {
-    while [[ -n "$1" ]]; do
-      ARG="$1"
+  while [[ -n "$1" ]]; do
+    ARG="$1"
+    shift
+
+    case "${ARG}" in
+    --DebugMode)
+      DEBUG_MODE="$1"
       shift
+      ;;    
+    --SorobanExamplesGitHash)
+      SOROBAN_EXAMPLES_GIT_HASH="$1"
+      shift
+      ;;     
+    --SorobanExamplesRepoURL)
+      SOROBAN_EXAMPLES_REPO_URL="$1"
+      shift
+      ;;   
+    --TestFilter)
+      TEST_FILTER="-test.run ""$1"""
+      shift
+      ;;     
+    --VerboseOutput)
+      VERBOSE_OUTPUT="$1"
+      shift
+      ;;  
+    --TargetNetwork)
+      TARGET_NETWORK="$1"
+      shift
+      ;;  
+    --TargetNetworkPassphrase) 
+      TARGET_NETWORK_PASSPHRASE="$1"
+      shift
+      ;;    
+    --TargetNetworkTestAccountSecret) 
+      TARGET_NETWORK_SECRET_KEY="$1"
+      shift
+      ;;    
+    --TargetNetworkTestAccountPublic) 
+      TARGET_NETWORK_PUBLIC_KEY="$1"
+      shift
+      ;;       
+    --TargetNetworkRPCURL) 
+      TARGET_NETWORK_RPC_URL="$1"
+      shift
+      ;;            
+    *)
+    esac
+  done
 
-      case "${ARG}" in
-      --DebugMode)
-        DEBUG_MODE="$1"
-        shift
-        ;;    
-      --RustToolchainVersion)
-        RUST_TOOLCHAIN_VERSION="$1"
-        shift
-        ;;  
-      --CoreDebianVersion)
-        CORE_DEBIAN_VERSION="$1"
-        shift
-        ;;
-      --HorizonDebianVersion)
-        HORIZON_DEBIAN_VERSION="$1"
-        shift
-        ;;  
-      --SorobanRPCDebianVersion)
-        SOROBAN_RPC_DEBIAN_VERSION="$1"
-        shift
-        ;; 
-      --SorobanRPCSourceVolume)
-        SOROBAN_RPC_SOURCE_VOLUME="$1"
-        shift
-        ;;   
-      --SorobanCLICrateVersion)
-        SOROBAN_CLI_CRATE_VERSION="$1"
-        shift
-        ;;  
-      --SorobanCLISourceVolume)
-        SOROBAN_CLI_SOURCE_VOLUME="$1"
-        shift
-        ;;      
-      --SorobanJSClientNpmVersion)
-        SOROBAN_JS_CLIENT_NPM_VERSION="$1"
-        shift
-        ;;   
-      --SorobanExamplesGitHash)
-        SOROBAN_EXAMPLES_GIT_HASH="$1"
-        shift
-        ;;     
-      --SorobanExamplesRepoURL)
-        SOROBAN_EXAMPLES_REPO_URL="$1"
-        shift
-        ;;   
-      --TestFilter)
-        TEST_FILTER="-test.run ""$1"""
-        shift
-        ;;     
-      --VerboseOutput)
-        VERBOSE_OUTPUT="$1"
-        shift
-        ;;  
-      --RunTargetStackOnly)
-        RUN_TARGET_STACK_ONLY="$1"
-        shift
-        ;;    
-      --TargetNetwork)
-        TARGET_NETWORK="$1"
-        shift
-        ;;  
-      --TargetNetworkPassphrase) 
-        TARGET_NETWORK_PASSPHRASE="$1"
-        shift
-        ;;    
-      --TargetNetworkTestAccountSecret) 
-        TARGET_NETWORK_SECRET_KEY="$1"
-        shift
-        ;;    
-      --TargetNetworkTestAccountPublic) 
-        TARGET_NETWORK_PUBLIC_KEY="$1"
-        shift
-        ;;       
-      --TargetNetworkRPCURL) 
-        TARGET_NETWORK_RPC_URL="$1"
-        shift
-        ;;            
-      *)
-      esac
-    done
+  if [ -z "$TARGET_NETWORK_RPC_URL" ] && [ -z "$TARGET_NETWORK" ]; then
+      TARGET_NETWORK=standalone
+  fi 
+}
 
-    if [ -z "$TARGET_NETWORK_RPC_URL" ] && [ -z "$TARGET_NETWORK" ]; then
-        TARGET_NETWORK=standalone
+function soroban_rpc_status () {
+  print_screen_output "waiting for soroban rpc to report ready state..." 
+  COUNTER=1
+  while ! $(curl --silent --location --request POST 'http://localhost:8000/soroban/rpc' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{
+        "jsonrpc": "2.0",
+        "id": 10235,
+        "method": "getHealth"
+        
+    }' | jq --exit-status '.result.status == "healthy"' 2>/dev/null | grep -o true || echo false ); 
+  do
+    if [ $(expr $COUNTER % 12) -eq 0 ]; then 
+      print_screen_output "waited $(expr $COUNTER / 12) minutes for soroban rpc to report ready state..." 
+    fi
+    COUNTER=$[$COUNTER +1]    
+    sleep 5
+  done 
+  print_screen_output "soroban rpc reported ready status, the service can be used by tools/cli now ..." 
+}
+
+function horizon_status () {
+  COUNTER=1
+  print_screen_output "waiting for horizon ingestion to be caught up to network current ledger..." 
+  while ! $(curl --silent --location --request GET 'http://localhost:8000' | \
+    jq --exit-status '.core_latest_ledger > 5 and .history_latest_ledger > 5 and (.core_latest_ledger - .history_latest_ledger) < 5' 2>/dev/null | \
+    grep -o true || echo false ); 
+  do
+    if [ $(expr $COUNTER % 12) -eq 0 ]; then 
+      print_screen_output "waited $(expr $COUNTER / 12) minutes for horizon ingestion to be caught up to network current ledger..." 
     fi 
-}
-
-function validateHorizon () {
-    COUNTER=1
-    while ! (curl --silent --location --request GET 'http://localhost:8000' | jq --exit-status '.history_latest_ledger > 0' > /dev/null 2>&1 ); do
-      if [ $COUNTER -gt 24 ]; then 
-          echo "Horizon ingestion did not become available in 2 minutes, aborting test ..."
-          exit 1
-      fi 
-      echo "Waiting for horizon ingestion to be caught up ..."
-      sleep 5
-      COUNTER=$[$COUNTER +1]
-    done 
-    echo "Horizon ingestion is moving forward ..."
-}
-
-function validateSorobanRPC () {
-    COUNTER=1
-    while ! (curl --silent --location --request POST "$TARGET_NETWORK_RPC_URL" \
-                --header 'Content-Type: application/json' \
-        --data-raw '{
-          "jsonrpc": "2.0",
-          "id": 10235,
-          "method": "getHealth"
-          
-        }' | jq --exit-status '.result.status == "healthy"' > /dev/null 2>&1 ); do
-      if [ $COUNTER -gt 24 ]; then 
-          echo "Soroban rpc did not become available in 2 minutes, aborting test ..."
-          exit 1
-      fi 
-      echo "Waiting for soroban rpc to be available..."
-      sleep 5
-      COUNTER=$[$COUNTER +1]
-    done 
-    echo "Soroban rpc is running ..."
+    COUNTER=$[$COUNTER +1] 
+    sleep 5
+  done 
+  print_screen_output "horizon ingestion is caught up to network current ledger ..." 
 }
 
 main "$@"


### PR DESCRIPTION
SystemTest uses `stellar/quickstart:soroban-dev` as a base image for running core, horizon, soroban rpc across various network configs. After soroban rpc was changed to use captive core at runtime, quickstart was changed to launch that new config - https://github.com/stellar/quickstart/pull/414

This PR is focused on hooking up the existing tests config to use the newer quickstart layout for rpc server. 
As part of this newer integration, refactored how system test image references quickstart as a base, rather then hardcoding a pinned hash version of quickstart:soroban-dev in Dockerfile. 
System test now provides a Makefile and clearer 2-step process to running tests:

Closes: #17 

(1) build system test image locally with versions configurable as git references for each component(quickstart, core, horizon, rpc)
```
$ make CORE_GIT_REF=f1dc39f0f146815e5e3a94ed162e2f0639cb433f \
              CORE_COMPILE_CONFIGURE_FLAGS="--disable-tests --enable-next-protocol-version-unsafe-for-production" \
              SOROBAN_RPC_GIT_REF=main \
              RUST_TOOLCHAIN_VERSION=1.66.0 \
              SOROBAN_CLI_GIT_REF=main \
              QUICKSTART_GIT_REF=master \
              build
...
...
=> => writing image sha256:9213fed54a95d6d9508a318fe2ab021552eb54d84acfff666726bf5e1302cd89                                                                                                             0.0s
 => => naming to docker.io/stellar/system-test:dev  
```
(2) execute the tests from that locally built image. this has the advantage of making the system test image by default in the host platform arch, so it quietly resolves the amd64/arm64 decision, as you don't have to think about that anymore, and eliminates the docker qemu slowness for arm64 that was on prior versions that forced amd64 platform emu.
```
$ docker run --rm -it --name e2e_test stellar/system-test:dev --VerboseOutput false
Starting system test ...
starting target stack on standalone with following server versions:
  CORE VERSION=f1dc39f
rust version: rustc 1.66.1 (90743e729 2023-01-10)
soroban-env-host: 
    package version: 0.0.11
    git version: 258b86dfc3a64a7004e7cc5c0e5d0c3312e8c69e
    interface version: 27
    rs-stellar-xdr:
        package version: 0.0.11
        git version: dbf2abab7cfde069f89ec5846a1c0c75ce4764ef
        base XDR git version: next
  HORIZON VERSION=77cf2ca9d550e26091f6e5cca3ae60cb81863c87-(built-from-source)
go1.19.3
  SOROBAN RPC VERSION=soroban-rpc dev
waiting for horizon ingestion to be caught up to network current ledger...
horizon ingestion is caught up to network current ledger ...
waiting for soroban rpc to report ready state...
soroban rpc reported ready status, the service can be used by tools/cli now ...
  RUST_TOOLCHAIN_VERSION=rustc 1.66.0 (69f9c33d7 2022-12-12)
  SOROBAN_CLI_CRATE_VERSION=soroban 0.4.0 (9d23a4bd733f3b18cda275fd28a5a3e40ddf9437)
soroban-env 0.0.12 (993c527abce72748405d71467498bffd63e061c1)
soroban-env interface version 27
stellar-xdr 0.0.12 (154e07ebbb0ad307475fd665d5a0dcf169a9596f)
xdr next (026c9cd074bdb28ddde8ee52f2a4502d9e518a09)
  SOROBAN_EXAMPLES_GIT_HASH=main
  SOROBAN_EXAMPLES_REPO_URL=https://github.com/stellar/soroban-examples.git
  TARGET_NETWORK=standalone
  TARGET_NETWORK_PASSPHRASE=Standalone Network ; February 2017
  TARGET_NETWORK_SECRET_KEY=SC5O7VZUXDJ6JBDSZ74DSERXL7W3Y5LTOAMRF7RQRL3TAGAPS7LUVG3L
  TARGET_NETWORK_PUBLIC_KEY=GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI
  TARGET_NETWORK_RPC_URL=http://localhost:8000/soroban/rpc
  TEST_FILTER=
Tests can now begin ...
Running test binary ./dapp_develop_test ... 
=== RUN   TestDappDevelop
Feature: DApp Contract Development
=== RUN   TestDappDevelop/DApp_developer_compiles,_installs,_deploys_and_invokes_a_contract

  Scenario Outline: DApp developer compiles, installs, deploys and invokes a contract                          # dapp_develop.feature:3
    Given I used cli to compile example contract <ContractExampleSubPath>                                      # dapp_develop_test.go:79 -> github.com/stellar/system-test/features/dapp_develop.compileContract
    And I used rpc to verify my account is on the network                                                      # dapp_develop_test.go:244 -> github.com/stellar/system-test/features/dapp_develop.queryAccount
    And I used cli to install contract <ContractCompiledFileName> on ledger using my account to network        # dapp_develop_test.go:152 -> github.com/stellar/system-test/features/dapp_develop.installContract
    And I used cli to deploy contract <ContractCompiledFileName> by installed hash using my account to network # dapp_develop_test.go:113 -> github.com/stellar/system-test/features/dapp_develop.deployContract
    When I invoke function <FunctionName> on <ContractName> with request parameter <Param1> from <Tool>        # dapp_develop_test.go:179 -> github.com/stellar/system-test/features/dapp_develop.invokeContract
    Then the result should be <Result>                                                                         # dapp_develop_test.go:236 -> github.com/stellar/system-test/features/dapp_develop.theResultShouldBe

    Examples:
      | Tool | ContractExampleSubPath | ContractName                 | ContractCompiledFileName          | FunctionName | Param1     | Result            |
      | CLI  | hello_world            | soroban-hello-world-contract | soroban_hello_world_contract.wasm | hello        | --to=Aloha | ["Hello","Aloha"] |
=== RUN   TestDappDevelop/DApp_developer_compiles,_installs,_deploys_and_invokes_a_contract#01
      | CLI  | increment              | soroban-increment-contract   | soroban_increment_contract.wasm   | increment    |            | 1                 |
=== RUN   TestDappDevelop/DApp_developer_compiles,_deploys_and_invokes_a_contract

  Scenario Outline: DApp developer compiles, deploys and invokes a contract                             # dapp_develop.feature:19
    Given I used cli to compile example contract <ContractExampleSubPath>                               # dapp_develop_test.go:79 -> github.com/stellar/system-test/features/dapp_develop.compileContract
    And I used rpc to verify my account is on the network                                               # dapp_develop_test.go:244 -> github.com/stellar/system-test/features/dapp_develop.queryAccount
    And I used cli to deploy contract <ContractCompiledFileName> using my account to network            # dapp_develop_test.go:113 -> github.com/stellar/system-test/features/dapp_develop.deployContract
    When I invoke function <FunctionName> on <ContractName> with request parameter <Param1> from <Tool> # dapp_develop_test.go:179 -> github.com/stellar/system-test/features/dapp_develop.invokeContract
    Then the result should be <Result>                                                                  # dapp_develop_test.go:236 -> github.com/stellar/system-test/features/dapp_develop.theResultShouldBe

    Examples:
      | Tool | ContractExampleSubPath | ContractName                 | ContractCompiledFileName          | FunctionName | Param1     | Result            |
      | CLI  | hello_world            | soroban-hello-world-contract | soroban_hello_world_contract.wasm | hello        | --to=Aloha | ["Hello","Aloha"] |
=== RUN   TestDappDevelop/DApp_developer_compiles,_deploys_and_invokes_a_contract#01
      | CLI  | increment              | soroban-increment-contract   | soroban_increment_contract.wasm   | increment    |            | 1                 |

4 scenarios (4 passed)
22 steps (22 passed)
2m26.261932399s
--- PASS: TestDappDevelop (146.26s)
    --- PASS: TestDappDevelop/DApp_developer_compiles,_installs,_deploys_and_invokes_a_contract (55.64s)
    --- PASS: TestDappDevelop/DApp_developer_compiles,_installs,_deploys_and_invokes_a_contract#01 (28.64s)
    --- PASS: TestDappDevelop/DApp_developer_compiles,_deploys_and_invokes_a_contract (33.23s)
    --- PASS: TestDappDevelop/DApp_developer_compiles,_deploys_and_invokes_a_contract#01 (28.75s)
PASS

```