### PR TITLE
fix futurenet target network option

### DIFF
--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -50,7 +50,7 @@ jobs:
              RUST_TOOLCHAIN_VERSION=${{ env.RUST_TOOLCHAIN_VERSION }} \
              SOROBAN_CLI_GIT_REF=${{ env.SOROBAN_CLI_GIT_REF }} \
              QUICKSTART_GIT_REF=${{ env.QUICKSTART_GIT_REF }} build;
-        docker save stellar/quickstart:dev -o /tmp/image;
+        docker save stellar/system-test:dev -o /tmp/image;
     - name: Upload System Test Image
       uses: actions/upload-artifact@v2
       with:

--- a/start
+++ b/start
@@ -72,8 +72,12 @@ function main() {
     print_screen_output "  HORIZON VERSION=$(stellar-horizon version 2>/dev/null || echo "n/a")"
     print_screen_output "  SOROBAN RPC VERSION=$(stellar-soroban-rpc version 2>/dev/null || echo "n/a")"
       
+    if [ "$TARGET_NETWORK" = "standalone" ]; then
+        ARTIFICIAL_ACCELERATE=--enable-core-artificially-accelerate-time-for-testing
+    fi          
+
     # using stdbuf to eliminate any buffering between pipe,   
-    stdbuf -o0 /start --$TARGET_NETWORK --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing --logs 2>&1 | stdbuf -i0 -o0 tee -a -i $LOG_FILE &
+    stdbuf -o0 /start --$TARGET_NETWORK --enable-soroban-rpc $ARTIFICIAL_ACCELERATE --logs 2>&1 | stdbuf -i0 -o0 tee -a -i $LOG_FILE &
     horizon_status
     soroban_rpc_status 
   else


### PR DESCRIPTION
Bug: Found problem when running the system-test image with `--TargetNetwork futurenet` option. it was trying to configure for artificial accelerate mode of core, but that is not valid for remote networks only standalone.

Fix: Added check for only doing artificial accelerate if target network is `standalone`.