### PR TITLE
Remove 'getAccount' soroban-rpc usage as it is deprecated

### DIFF
--- a/features/dapp_develop/dapp_develop_test.go
+++ b/features/dapp_develop/dapp_develop_test.go
@@ -33,13 +33,12 @@ type testConfig struct {
 	TestWorkingDir           string
 }
 
-type accountInfo struct {
-	ID       string `json:"id"`
-	Sequence int64  `json:"sequence,string"`
+type ledgerEntryResult struct {
+	XDR string `json:"xdr"`
 }
 
-type accountResponse struct {
-	Result accountInfo `json:"result"`
+type getLedgerEntryResponse struct {
+	Result ledgerEntryResult `json:"result"`
 }
 
 func TestDappDevelop(t *testing.T) {
@@ -243,13 +242,26 @@ func theResultShouldBe(ctx context.Context, expectedResult string) error {
 
 func queryAccount(ctx context.Context) error {
 	testConfig := ctx.Value(e2e.TestConfigContextKey).(*testConfig)
+	decoded, err := strkey.Decode(strkey.VersionByteAccountID, testConfig.E2EConfig.TargetNetworkPublicKey)
+	if err != nil {
+		return fmt.Errorf("invalid address: %v", testConfig.E2EConfig.TargetNetworkPublicKey)
+	}
+	var key xdr.Uint256
+	copy(key[:], decoded)
+	key, err := xdr.LedgerEntryKey{
+		Type: xdr.LedgerEntryTypeAccount,
+		A:    &xdr.LedgerEntryKeyAccount{AccountId: key},
+	}.MarshalBinaryBase64()
+	if err != nil {
+		return err
+	}
 
 	getAccountRequest := []byte(`{
            "jsonrpc": "2.0",
            "id": 10235,
-           "method": "getAccount",
+           "method": "getLedgerEntry",
            "params": { 
-               "address": "` + testConfig.E2EConfig.TargetNetworkPublicKey + `"
+               "key": "` + key + `"
             }
         }`)
 
@@ -258,7 +270,7 @@ func queryAccount(ctx context.Context) error {
 		return fmt.Errorf("soroban rpc get account had error %e", err)
 	}
 
-	var rpcResponse accountResponse
+	var rpcResponse getLedgerEntryResponse
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(&rpcResponse)
 	if err != nil {
@@ -266,7 +278,7 @@ func queryAccount(ctx context.Context) error {
 	}
 
 	var t e2e.Asserter
-	assert.Equal(&t, testConfig.E2EConfig.TargetNetworkPublicKey, rpcResponse.Result.ID, "RPC get account, Expected %v but got %v", testConfig.E2EConfig.TargetNetworkPublicKey, rpcResponse.Result.ID)
+	assert.NotEmpty(&t, rpcResponse.Result.XDR, "RPC get account, account not found")
 	return t.Err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,10 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-memdb v1.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stellar/go v0.0.0-20230216182126-bc7f94cc35b6 // indirect
+	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -181,6 +183,10 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/stellar/go v0.0.0-20230216182126-bc7f94cc35b6 h1:K94rhFNz3zKCTkRXyU5EQxRuui4PPAI1HmweVOv4pvQ=
+github.com/stellar/go v0.0.0-20230216182126-bc7f94cc35b6/go.mod h1:VQE2/C8c5lqHVMbtN1SvFHSqZ7pKKXdrexU2lRT2QGk=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Fixes test fail in https://github.com/stellar/soroban-tools/pull/439

# Issues

Adds an awkward dependency on `github.com/stellar/go/xdr`