### PR TITLE
removing phantomjs from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,6 @@ ENV RUST_TOOLCHAIN_VERSION=$RUST_TOOLCHAIN_VERSION
 ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN_VERSION"
 
-# Install phantomjs
-RUN test "$(dpkg --print-architecture)" == *"arm"* && apt -y install phantomjs=2.1.1+dfsg-2ubuntu1 || apt -y install phantomjs
-ENV QT_QPA_PLATFORM=offscreen
-
 # Use a non-root user
 ARG USERNAME=tester
 ARG USER_UID=1000
@@ -71,7 +67,8 @@ RUN npm i -g ts-node
 # Install js-soroban-client
 ARG JS_SOROBAN_CLIENT_NPM_VERSION
 ADD package*.json /home/tester/
-RUN npm ci && npm install "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
+RUN npm install "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
+RUN npm ci
 ADD *.ts /home/tester/bin/
 RUN ["sudo", "chmod", "+x", "/home/tester/bin/invoke.ts"]
 


### PR DESCRIPTION
During image build, getting errors due to no phantomjs available from apt package on ubuntu 22.04.  

https://github.com/stellar/soroban-tools/actions/runs/4747312880/jobs/8432059319#step:5:8152

phantomjs is not used by anything in the test image, it was being referenced by js-sorobn-client as a dev dependency that was not used. Have related[ js-soroban-sdk#68](https://github.com/stellar/js-soroban-client/pull/68) to remove it from that project. once that merges then this build should work and can merge.

