### PR TITLE
tests use new output paths compiled wasm in soroban-examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,14 @@ RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/home/tester/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-RUN npm i -g ts-node
+RUN npm install -g ts-node yarn
 
 # Install js-soroban-client
 ARG JS_SOROBAN_CLIENT_NPM_VERSION
-ADD package*.json /home/tester/
-RUN npm install "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
-RUN npm ci
+ADD package.json /home/tester/
+RUN sudo chown -R tester:tester /home/tester
+RUN yarn add "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
+RUN yarn install
 ADD *.ts /home/tester/bin/
 RUN ["sudo", "chmod", "+x", "/home/tester/bin/invoke.ts"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ RUN npm install -g ts-node yarn
 ARG JS_SOROBAN_CLIENT_NPM_VERSION
 ADD package.json /home/tester/
 RUN sudo chown -R tester:tester /home/tester
-RUN yarn install
-RUN yarn add "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
+RUN yarn install --network-concurrency 1
+RUN yarn add "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}" --network-concurrency 1
 ADD *.ts /home/tester/bin/
 RUN ["sudo", "chmod", "+x", "/home/tester/bin/invoke.ts"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ RUN npm install -g ts-node yarn
 ARG JS_SOROBAN_CLIENT_NPM_VERSION
 ADD package.json /home/tester/
 RUN sudo chown -R tester:tester /home/tester
-RUN yarn add "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
 RUN yarn install
+RUN yarn add "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}"
 ADD *.ts /home/tester/bin/
 RUN ["sudo", "chmod", "+x", "/home/tester/bin/invoke.ts"]
 

--- a/features/dapp_develop/dapp_develop.feature
+++ b/features/dapp_develop/dapp_develop.feature
@@ -5,8 +5,8 @@ Feature: DApp Contract Development
 Scenario Outline: DApp developer compiles, installs, deploys and invokes a contract
   Given I used cargo to compile example contract <ContractExampleSubPath>
   And I used rpc to verify my account is on the network
-  And I used cli to install contract <ContractCompiledFileName> on network using my secret key
-  And I used cli to deploy contract <ContractCompiledFileName> by installed hash using my secret key
+  And I used cli to install contract <ContractExampleSubPath> / <ContractCompiledFileName> on network using my secret key
+  And I used cli to deploy contract <ContractExampleSubPath> / <ContractCompiledFileName> by installed hash using my secret key
   When I invoke function <FunctionName> on <ContractName> with request parameters <FunctionParams> from tool <Tool> using my secret key
   Then The result should be <Result>
 
@@ -23,7 +23,7 @@ Scenario Outline: DApp developer compiles, deploys and invokes a contract
   And I used cargo to compile example contract <ContractExampleSubPath>
   And I used rpc to verify my account is on the network
   And I used rpc to get network latest ledger
-  And I used cli to deploy contract <ContractCompiledFileName> using my secret key
+  And I used cli to deploy contract <ContractExampleSubPath> / <ContractCompiledFileName> using my secret key
   When I invoke function <FunctionName> on <ContractName> with request parameters <FunctionParams> from tool <Tool> using my secret key
   Then The result should be <Result>
   And The result should be to receive <EventCount> contract events and <DiagEventCount> diagnostic events for <ContractName> from <Tool>
@@ -43,7 +43,7 @@ Scenario Outline: DApp developer uses config states, compiles, deploys and invok
   And I used cli to add Network Config <NetworkConfigName> for rpc and standalone
   And I used cli to add Identity <RootIdentityName> for my secret key
   And I used cli to add Identity <TesterIdentityName> for tester secret key
-  And I used cli to deploy contract <ContractCompiledFileName> using Identity <RootIdentityName> and Network Config <NetworkConfigName>
+  And I used cli to deploy contract <ContractExampleSubPath> / <ContractCompiledFileName> using Identity <RootIdentityName> and Network Config <NetworkConfigName>
   When I invoke function <FunctionName> on <ContractName> with request parameters <FunctionParams> from tool <Tool> using Identity <TesterIdentityName> as invoker and Network Config <NetworkConfigName>
   Then The result should be <Result>
 

--- a/features/dapp_develop/dapp_develop_test.go
+++ b/features/dapp_develop/dapp_develop_test.go
@@ -77,37 +77,37 @@ func compileContractStep(ctx context.Context, contractExamplesSubPath string) er
 	return compileContract(contractExamplesSubPath, contractWorkingDirectory, testConfig.E2EConfig)
 }
 
-func deployContractStep(ctx context.Context, compiledContractFileName string) error {
+func deployContractStep(ctx context.Context, contractExamplesSubPath string, compiledContractFileName string) error {
 	testConfig := ctx.Value(e2e.TestConfigContextKey).(*testConfig)
 	contractWorkingDirectory := fmt.Sprintf("%s/soroban_examples", testConfig.TestWorkingDir)
 
 	var err error
-	if testConfig.DeployedContractId, err = deployContract(compiledContractFileName, contractWorkingDirectory, testConfig.InstalledContractId, testConfig.E2EConfig); err != nil {
+	if testConfig.DeployedContractId, err = deployContract(compiledContractFileName, contractWorkingDirectory, contractExamplesSubPath, testConfig.InstalledContractId, testConfig.E2EConfig); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func deployContractUsingConfigParamsStep(ctx context.Context, compiledContractFileName string, identityName string, networkConfigName string) error {
+func deployContractUsingConfigParamsStep(ctx context.Context, contractExamplesSubPath string, compiledContractFileName string, identityName string, networkConfigName string) error {
 	testConfig := ctx.Value(e2e.TestConfigContextKey).(*testConfig)
 	contractWorkingDirectory := fmt.Sprintf("%s/soroban_examples", testConfig.TestWorkingDir)
 
 	var err error
-	if testConfig.DeployedContractId, err = deployContractUsingConfigParams(compiledContractFileName, contractWorkingDirectory, identityName, networkConfigName, testConfig.E2EConfig); err != nil {
+	if testConfig.DeployedContractId, err = deployContractUsingConfigParams(compiledContractFileName, contractWorkingDirectory, contractExamplesSubPath, identityName, networkConfigName, testConfig.E2EConfig); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func installContractStep(ctx context.Context, compiledContractFileName string) error {
+func installContractStep(ctx context.Context, contractExamplesSubPath string, compiledContractFileName string) error {
 
 	testConfig := ctx.Value(e2e.TestConfigContextKey).(*testConfig)
 	contractWorkingDirectory := fmt.Sprintf("%s/soroban_examples", testConfig.TestWorkingDir)
 
 	var err error
-	if testConfig.InstalledContractId, err = installContract(compiledContractFileName, contractWorkingDirectory, testConfig.E2EConfig); err != nil {
+	if testConfig.InstalledContractId, err = installContract(compiledContractFileName, contractWorkingDirectory, contractExamplesSubPath, testConfig.E2EConfig); err != nil {
 		return err
 	}
 
@@ -337,10 +337,10 @@ func initializeScenario(scenarioCtx *godog.ScenarioContext) {
 		scenarioCtx.Step(`^I used rpc to submit transaction to create tester account on the network$`, createTesterAccountStep)
 		scenarioCtx.Step(`^I used cli to add Network Config ([\S|\s]+) for rpc and standalone$`, createNetworkConfigStep)
 		scenarioCtx.Step(`^I used cli to add Identity ([\S|\s]+) for my secret key$`, createMyIdentityStep)
-		scenarioCtx.Step(`^I used cli to deploy contract ([\S|\s]+) using Identity ([\S|\s]+) and Network Config ([\S|\s]+)$`, deployContractUsingConfigParamsStep)
-		scenarioCtx.Step(`^I used cli to install contract ([\S|\s]+) on network using my secret key$`, installContractStep)
-		scenarioCtx.Step(`^I used cli to deploy contract ([\S|\s]+) by installed hash using my secret key$`, deployContractStep)
-		scenarioCtx.Step(`^I used cli to deploy contract ([\S|\s]+) using my secret key$`, deployContractStep)
+		scenarioCtx.Step(`^I used cli to deploy contract ([\S|\s]+) / ([\S|\s]+) using Identity ([\S|\s]+) and Network Config ([\S|\s]+)$`, deployContractUsingConfigParamsStep)
+		scenarioCtx.Step(`^I used cli to install contract ([\S|\s]+) / ([\S|\s]+) on network using my secret key$`, installContractStep)
+		scenarioCtx.Step(`^I used cli to deploy contract ([\S|\s]+) / ([\S|\s]+) by installed hash using my secret key$`, deployContractStep)
+		scenarioCtx.Step(`^I used cli to deploy contract ([\S|\s]+) / ([\S|\s]+) using my secret key$`, deployContractStep)
 		scenarioCtx.Step(`^I used cli to add Identity ([\S|\s]+) for tester secret key$`, createTestAccountIdentityStep)
 		scenarioCtx.Step(`^I invoke function ([\S|\s]+) on ([\S|\s]+) with request parameters ([\S|\s]*) from tool ([\S|\s]+) using Identity ([\S|\s]+) as invoker and Network Config ([\S|\s]+)$`, invokeContractStepWithConfig)
 		scenarioCtx.Step(`^I invoke function ([\S|\s]+) on ([\S|\s]+) with request parameters ([\S|\s]*) from tool ([\S|\s]+) using my secret key$`, invokeContractStep)

--- a/features/dapp_develop/main.go
+++ b/features/dapp_develop/main.go
@@ -39,7 +39,7 @@ func compileContract(contractExamplesSubPath string, contractWorkingDirectory st
 }
 
 // returns the deployed contract id
-func deployContract(compiledContractFileName string, contractWorkingDirectory string, installedContractId string, e2eConfig *e2e.E2EConfig) (string, error) {
+func deployContract(compiledContractFileName string, contractWorkingDirectory string, contractExamplesSubPath string, installedContractId string, e2eConfig *e2e.E2EConfig) (string, error) {
 	var envCmd *cmd.Cmd
 
 	if installedContractId != "" {
@@ -54,7 +54,7 @@ func deployContract(compiledContractFileName string, contractWorkingDirectory st
 		envCmd = cmd.NewCmd("soroban",
 			"contract",
 			"deploy",
-			"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
+			"--wasm", fmt.Sprintf("./%s/%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, contractExamplesSubPath, compiledContractFileName),
 			"--rpc-url", e2eConfig.TargetNetworkRPCURL,
 			"--source", e2eConfig.TargetNetworkSecretKey,
 			"--network-passphrase", e2eConfig.TargetNetworkPassPhrase)
@@ -73,11 +73,11 @@ func deployContract(compiledContractFileName string, contractWorkingDirectory st
 	return stdOut[0], nil
 }
 
-func deployContractUsingConfigParams(compiledContractFileName string, contractWorkingDirectory string, identityName string, networkConfigName string, e2eConfig *e2e.E2EConfig) (string, error) {
+func deployContractUsingConfigParams(compiledContractFileName string, contractWorkingDirectory string, contractExamplesSubPath string, identityName string, networkConfigName string, e2eConfig *e2e.E2EConfig) (string, error) {
 	envCmd := cmd.NewCmd("soroban",
 		"contract",
 		"deploy",
-		"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
+		"--wasm", fmt.Sprintf("./%s/%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, contractExamplesSubPath, compiledContractFileName),
 		"--network", networkConfigName,
 		"--source", identityName)
 
@@ -95,11 +95,11 @@ func deployContractUsingConfigParams(compiledContractFileName string, contractWo
 }
 
 // returns the installed contract id
-func installContract(compiledContractFileName string, contractWorkingDirectory string, e2eConfig *e2e.E2EConfig) (string, error) {
+func installContract(compiledContractFileName string, contractWorkingDirectory string, contractExamplesSubPath string, e2eConfig *e2e.E2EConfig) (string, error) {
 	envCmd := cmd.NewCmd("soroban",
 		"contract",
 		"install",
-		"--wasm", fmt.Sprintf("./%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, compiledContractFileName),
+		"--wasm", fmt.Sprintf("./%s/%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, contractExamplesSubPath, compiledContractFileName),
 		"--rpc-url", e2eConfig.TargetNetworkRPCURL,
 		"--source", e2eConfig.TargetNetworkSecretKey,
 		"--network-passphrase", e2eConfig.TargetNetworkPassPhrase)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "argparse": "^2.0.1",
-    "soroban-client": "git+https://github.com/stellar/js-soroban-client.git#main",
     "tslib": "^2.5.0",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
the output path for compiled wasm in soroban-examples changed to be under each sub-project/target, changed tests to reference this path during test contract compilation steps.