### PR TITLE
remove usage of `accelerate` flag on quickstart startup flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This approach allows to run the tests from source code directly on host as go te
  3. `soroban`, compile or install via cargo crate a version of soroban cli onto your machine and accessible from PATH.
  4. target network stack for the tests to access soroban-rpc instance. You can use an existing/running instance if reachable or can use the quickstart image `stellar/quickstart:soroban-dev` from dockerhub to run the latest stable target network stack locally, or build quickstart with specific versions of core, horizon and soroban rpc first [following these instructions](https://github.com/stellar/quickstart#building-custom-images) and run `stellar/quickstart:dev` locally.
      ```
-     docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:dev --standalone --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing
+     docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:dev --standalone --enable-soroban-rpc
      ```
  5. locally checkout stellar/system-test GH repo and go into top folder - `git clone https://github.com/stellar/system-test.git;cd system-test`
  

--- a/start
+++ b/start
@@ -80,18 +80,17 @@ function main() {
     print_screen_output "  SOROBAN RPC VERSION=$(stellar-soroban-rpc version 2>/dev/null || echo "n/a")"
       
     if [ "$TARGET_NETWORK" = "standalone" ]; then
-        ARTIFICIAL_ACCELERATE=--enable-core-artificially-accelerate-time-for-testing
         ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=--enable-soroban-diagnostic-events
     fi        
 
     if [ "$VERBOSE_OUTPUT" = "true" ]; then
         # redirects all quickstart output to console during test execution
-        /start --$TARGET_NETWORK --enable-soroban-rpc $ARTIFICIAL_ACCELERATE $ENABLE_SOROBAN_DIAGNOSTIC_EVENTS --logs 2>&1 &
+        /start --$TARGET_NETWORK --enable-soroban-rpc $ENABLE_SOROBAN_DIAGNOSTIC_EVENTS --logs 2>&1 &
     else
         # don't show any quickstart output on console during test execution
         # all quickstart output is redirected(buffering disabled) to log file, which will be dumped to
         # console if tests fail.
-        stdbuf -o0 -e0 /start --$TARGET_NETWORK --enable-soroban-rpc $ARTIFICIAL_ACCELERATE $ENABLE_SOROBAN_DIAGNOSTIC_EVENTS --logs >> $QUICKSTART_LOG_FILE 2>&1 &
+        stdbuf -o0 -e0 /start --$TARGET_NETWORK --enable-soroban-rpc $ENABLE_SOROBAN_DIAGNOSTIC_EVENTS --logs >> $QUICKSTART_LOG_FILE 2>&1 &
     fi
   fi
 


### PR DESCRIPTION
quickstart has deprecated the artificial acceleration flag, remove usage of it.