### PR TITLE
Still need to hex-ify the contract id for getEvents

### DIFF
--- a/events.ts
+++ b/events.ts
@@ -24,7 +24,7 @@ async function main() {
 
   if (contractId != null) {
     filters.push({
-      contractIds: [ contractId ]
+      contractIds: [ new SorobanClient.Contract(contractId).contractId('hex') ]
     });
   }
 


### PR DESCRIPTION
The work in https://github.com/stellar/soroban-tools/pull/668, where the cli returns a C-strkey for contracts, conflicts with the current need for the RPC-server to take a hex contract ID for getEvents. This bridges that gap for now.