### PR TITLE
Migrate invocation parsing to Preview 10 XDR structure

### DIFF
--- a/invoke.ts
+++ b/invoke.ts
@@ -71,26 +71,7 @@ async function main() {
       const result = xdr.TransactionResultMeta.fromXDR(response.resultMetaXdr!, "base64");
       const scval = result.txApplyProcessing().v3().sorobanMeta()?.returnValue()!;
 
-      // Hacky result parsing. We should have some helpers from the
-      // js-stellar-base, or the generated Typescript bindings.
-      let parsed: number | object | null = null;
-      switch (scval.switch()) {
-      case xdr.ScValType.scvU32(): {
-        parsed = scval.u32();
-        break;
-      }
-      case xdr.ScValType.scvI32(): {
-        parsed = scval.i32();
-        break;
-      }
-      case xdr.ScValType.scvVec(): {
-        // Total hack, we just assume the object is a vec. Good enough for now.
-        parsed = scval.vec()!.map(v => v.sym().toString());
-        break;
-      }
-      default:
-        throw new Error(`Unexpected scval type: ${scval.switch().name}`);
-      }
+      const parsed = SorobanClient.scValToNative(scval);
       console.log(JSON.stringify(parsed));
       return;
     }

--- a/invoke.ts
+++ b/invoke.ts
@@ -67,9 +67,9 @@ async function main() {
         throw new Error(`No result meta XDR: ${JSON.stringify(response)}`);
       }
 
-      const result = xdr.TransactionResultMeta.fromXDR(response.resultMetaXdr, "base64");
+      const result = xdr.TransactionMeta.fromXDR(response.resultMetaXdr, "base64");
       // TODO: Move this scval serializing stuff to stellar-base
-      const scval = result.txApplyProcessing().v3().sorobanMeta()?.returnValue()!;
+      const scval = result.v3().sorobanMeta()?.returnValue()!;
       const parsed = SorobanClient.scValToNative(scval);
       console.log(JSON.stringify(parsed));
       return;

--- a/invoke.ts
+++ b/invoke.ts
@@ -63,14 +63,13 @@ async function main() {
       break;
     }
     case "SUCCESS": {
-      // parse and print the response (assuming it is a vec)
-      // TODO: Move this scval serializing stuff to stellar-base
-      if (!response.resultXdr) {
-          throw new Error(`No result XDR: ${JSON.stringify(response)}`);
+      if (!response.resultMetaXdr) {
+        throw new Error(`No result meta XDR: ${JSON.stringify(response)}`);
       }
-      const result = xdr.TransactionResultMeta.fromXDR(response.resultMetaXdr!, "base64");
-      const scval = result.txApplyProcessing().v3().sorobanMeta()?.returnValue()!;
 
+      const result = xdr.TransactionResultMeta.fromXDR(response.resultMetaXdr, "base64");
+      // TODO: Move this scval serializing stuff to stellar-base
+      const scval = result.txApplyProcessing().v3().sorobanMeta()?.returnValue()!;
       const parsed = SorobanClient.scValToNative(scval);
       console.log(JSON.stringify(parsed));
       return;


### PR DESCRIPTION
Previously, we extracted the return value from the `InvokeHostFunctionResult` in the `response.resultXdr`. In Preview 10, however, the result only contains a _hash_ of the return value, so we need to extract it from `response.resultMetaXdr`, instead, which is a `TransactionMeta`.

We can also leverage native functionality to turn this `ScVal` into JSON.