### PR TITLE
Properly convert a vec of symbols to strings

### DIFF
--- a/invoke.ts
+++ b/invoke.ts
@@ -73,10 +73,11 @@ async function main() {
 
       // Hack: Convert Vec<Buffer> to Vec<String> for stringification
       if (parsed.length !== 0 && ArrayBuffer.isView(parsed[0])) {
-        parsed = parsed.map(elem => elem.toString());
+        const decoder = new TextDecoder();
+        parsed = parsed.map(elem => decoder.decode(elem));
       }
-      console.log(JSON.stringify(parsed));
 
+      console.log(JSON.stringify(parsed));
       return;
     }
     case "FAILED": {

--- a/invoke.ts
+++ b/invoke.ts
@@ -66,11 +66,17 @@ async function main() {
         throw new Error(`No result meta XDR: ${JSON.stringify(response)}`);
       }
 
-      const result = SorobanClient.xdr.TransactionMeta.fromXDR(response.resultMetaXdr, "base64");
       // TODO: Move this scval serializing stuff to stellar-base
+      const result = SorobanClient.xdr.TransactionMeta.fromXDR(response.resultMetaXdr, "base64");
       const scval = result.v3().sorobanMeta()?.returnValue()!;
-      const parsed = SorobanClient.scValToNative(scval);
+      let parsed = SorobanClient.scValToNative(scval);
+
+      // Hack: Convert Vec<Buffer> to Vec<String> for stringification
+      if (parsed.length !== 0 && ArrayBuffer.isView(parsed[0])) {
+        parsed = parsed.map(elem => elem.toString());
+      }
       console.log(JSON.stringify(parsed));
+
       return;
     }
     case "FAILED": {


### PR DESCRIPTION
There's no reason to assume that **any** symbol should be interpreted as a string, but we know we can in this case, so we need to perform that conversion when appropriate.