### PR TITLE
js-soroban-client local file path installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,10 @@ ADD js-soroban-client /home/tester/js-soroban-client
 RUN sudo chown -R tester:tester /home/tester
 RUN yarn install --network-concurrency 1
 RUN if echo "$JS_SOROBAN_CLIENT_NPM_VERSION" | grep -q '.*file:.*'; then \
+  cd /home/tester/js-soroban-client; \
+  yarn cache clean; \
+  yarn install --network-concurrency 1; \
+  cd /home/tester; \
   yarn add ${JS_SOROBAN_CLIENT_NPM_VERSION} --network-concurrency 1; \
   else \
   yarn add "soroban-client@${JS_SOROBAN_CLIENT_NPM_VERSION}" --network-concurrency 1; \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SOROBAN_CLI_STAGE_IMAGE=stellar/system-test-soroban-cli:dev
 CORE_GIT_REF=https://github.com/stellar/stellar-core.git\#master
 SOROBAN_RPC_GIT_REF=https://github.com/stellar/soroban-tools.git\#main
 SOROBAN_CLI_GIT_REF=https://github.com/stellar/soroban-tools.git\#main
-GO_GIT_REF=https://github.com/stellar/go.git\#soroban-xdr-next
+GO_GIT_REF=https://github.com/stellar/go.git\#master
 QUICKSTART_GIT_REF=https://github.com/stellar/quickstart.git\#master
 # specify the published npm repo version of soroban-client js library, or you can specify gh git ref url as the version also
 JS_SOROBAN_CLIENT_NPM_VERSION=https://github.com/stellar/js-soroban-client.git\#main


### PR DESCRIPTION
when taking  a local file path for js-soroban-client, the docker build needs to `yarn install`on that local file path first to generate node_modules native to the docker run time, then it yarn adds the local js-soroban-client file path to system-test's package.json project for the test .ts scripts to refer to it.
