### PR TITLE
Upgrade+migrate soroban-client to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ SOROBAN_CLI_GIT_REF=https://github.com/stellar/soroban-tools.git\#main
 GO_GIT_REF=https://github.com/stellar/go.git\#soroban-xdr-next
 QUICKSTART_GIT_REF=https://github.com/stellar/quickstart.git\#master
 # specify the published npm repo version of soroban-client js library, or you can specify gh git ref url as the version also
-JS_SOROBAN_CLIENT_NPM_VERSION=https://github.com/stellar/js-soroban-client.git\#main
+JS_SOROBAN_CLIENT_NPM_VERSION=v1.0.0-beta.0
 
 # variables to set if wanting to use existing dockerhub images instead of compiling
-# image during build. if using this option, the image ref should provide a version for same 
+# image during build. if using this option, the image ref should provide a version for same
 # platform arch as the build host is on, i.e. linux/amd64 or linux/arm64.
 #
 # image must have soroban cli bin at /usr/local/cargo/bin/soroban
@@ -43,18 +43,18 @@ FRIENDBOT_IMAGE=
 # image must have core bin at /usr/local/bin/stellar-core
 CORE_IMAGE=
 #
-# a prebuilt 'soroban-dev' image from the quickstart repo, if this is supplied, 
+# a prebuilt 'soroban-dev' image from the quickstart repo, if this is supplied,
 # the other core, rpc, horizon, friendbot config settings are mostly ignored, since the quickstart image
 # has them compiled in already. the 'stellar/quickstart' images also support multi-arch, so the build will
 # work those images whether the build host is arm64 or amd64.
 QUICKSTART_IMAGE=
 
-NODE_VERSION?=14.20.0
+NODE_VERSION?=14.21.3
 
 # if crate version is set, then it overrides SOROBAN_CLI_GIT_REF, cli will be installed from this create instead
 SOROBAN_CLI_CRATE_VERSION=
 
-# sets the rustc version in the system test image 
+# sets the rustc version in the system test image
 RUST_TOOLCHAIN_VERSION=stable
 
 # temporarily needed, builds core with soroban enabled features
@@ -73,7 +73,7 @@ build-friendbot:
 		docker build -t "$(FRIENDBOT_STAGE_IMAGE)" \
 		--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true \
 		-f services/friendbot/docker/Dockerfile "$$SOURCE_URL"; \
-	fi	
+	fi
 
 build-soroban-rpc:
 	if [ -z "$(QUICKSTART_IMAGE)" ] && [ -z "$(SOROBAN_RPC_IMAGE)" ]; then \
@@ -109,7 +109,7 @@ build-horizon:
 		--target builder -f services/horizon/docker/Dockerfile.dev "$$SOURCE_URL"; \
 	fi
 
-build-core: 
+build-core:
 	if [ -z "$(QUICKSTART_IMAGE)" ] && [ -z "$(CORE_IMAGE)" ]; then \
 		SOURCE_URL="$(CORE_GIT_REF)"; \
 		if [[ ! "$(CORE_GIT_REF)" =~ \.git ]]; then \


### PR DESCRIPTION
This pins the version to v1.0.0-beta.0 published on npm (cc @sreuland, is it more convenient to just have it be `main`?)

It also updates `invoke.ts` to the new library usage, but I'm not sure where this file is used.