### PR TITLE
added git to system-test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG RUST_TOOLCHAIN_VERSION
 ARG NODE_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y build-essential expect && apt-get clean
+RUN apt-get update && apt-get install -y build-essential expect git && apt-get clean
 
 # Install Rust
 RUN ["mkdir", "-p", "/rust"] 


### PR DESCRIPTION
the base image from quickstart no longer includes the git cli bin, so, need to install it into the final system-test image 