### PR TITLE
system-test: Use --ignore-checks When Deploying & Installing Contracts

### DIFF
--- a/features/dapp_develop/main.go
+++ b/features/dapp_develop/main.go
@@ -42,6 +42,7 @@ func compileContract(contractExamplesSubPath string, contractWorkingDirectory st
 func deployContract(compiledContractFileName string, contractWorkingDirectory string, contractExamplesSubPath string, installedContractId string, e2eConfig *e2e.E2EConfig) (string, error) {
 	var envCmd *cmd.Cmd
 
+	// Always use --ignore-checks since system-test will use contracts compiled with RC versions of the Soroban Rust SDK.
 	if installedContractId != "" {
 		envCmd = cmd.NewCmd("soroban",
 			"contract",
@@ -49,7 +50,8 @@ func deployContract(compiledContractFileName string, contractWorkingDirectory st
 			"--wasm-hash", installedContractId,
 			"--rpc-url", e2eConfig.TargetNetworkRPCURL,
 			"--source", e2eConfig.TargetNetworkSecretKey,
-			"--network-passphrase", e2eConfig.TargetNetworkPassPhrase)
+			"--network-passphrase", e2eConfig.TargetNetworkPassPhrase,
+			"--ignore-checks")
 	} else {
 		envCmd = cmd.NewCmd("soroban",
 			"contract",
@@ -57,7 +59,8 @@ func deployContract(compiledContractFileName string, contractWorkingDirectory st
 			"--wasm", fmt.Sprintf("./%s/%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, contractExamplesSubPath, compiledContractFileName),
 			"--rpc-url", e2eConfig.TargetNetworkRPCURL,
 			"--source", e2eConfig.TargetNetworkSecretKey,
-			"--network-passphrase", e2eConfig.TargetNetworkPassPhrase)
+			"--network-passphrase", e2eConfig.TargetNetworkPassPhrase,
+			"--ignore-checks")
 	}
 
 	status, stdOut, err := e2e.RunCommand(envCmd, e2eConfig)
@@ -74,12 +77,14 @@ func deployContract(compiledContractFileName string, contractWorkingDirectory st
 }
 
 func deployContractUsingConfigParams(compiledContractFileName string, contractWorkingDirectory string, contractExamplesSubPath string, identityName string, networkConfigName string, e2eConfig *e2e.E2EConfig) (string, error) {
+	// Always use --ignore-checks since system-test will use contracts compiled with RC versions of the Soroban Rust SDK.
 	envCmd := cmd.NewCmd("soroban",
 		"contract",
 		"deploy",
 		"--wasm", fmt.Sprintf("./%s/%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, contractExamplesSubPath, compiledContractFileName),
 		"--network", networkConfigName,
-		"--source", identityName)
+		"--source", identityName,
+		"--ignore-checks")
 
 	status, stdOut, err := e2e.RunCommand(envCmd, e2eConfig)
 
@@ -96,13 +101,15 @@ func deployContractUsingConfigParams(compiledContractFileName string, contractWo
 
 // returns the installed contract id
 func installContract(compiledContractFileName string, contractWorkingDirectory string, contractExamplesSubPath string, e2eConfig *e2e.E2EConfig) (string, error) {
+	// Always use --ignore-checks since system-test will use contracts compiled with RC versions of the Soroban Rust SDK.
 	envCmd := cmd.NewCmd("soroban",
 		"contract",
 		"install",
 		"--wasm", fmt.Sprintf("./%s/%s/target/wasm32-unknown-unknown/release/%s", contractWorkingDirectory, contractExamplesSubPath, compiledContractFileName),
 		"--rpc-url", e2eConfig.TargetNetworkRPCURL,
 		"--source", e2eConfig.TargetNetworkSecretKey,
-		"--network-passphrase", e2eConfig.TargetNetworkPassPhrase)
+		"--network-passphrase", e2eConfig.TargetNetworkPassPhrase,
+		"--ignore-checks")
 
 	status, stdOut, err := e2e.RunCommand(envCmd, e2eConfig)
 


### PR DESCRIPTION
Follow up [from this PR](https://github.com/stellar/soroban-tools/pull/1061). This PR updates `install` and `deploy` to use the newly introduced `--ignore-checks` flag so the commands don't encounter an error when using contracts compiled with a RC version of our Soroban Rust SDK.