### PR TITLE
Updated for latest js sdk usage

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -89,7 +89,7 @@ type LatestLedgerResult struct {
 	// Hash of the latest ledger as a hex-encoded string
 	Hash string `json:"id"`
 	// Stellar Core protocol version associated with the ledger.
-	ProtocolVersion uint32 `json:"protocolVersion,string"`
+	ProtocolVersion uint32 `json:"protocolVersion"`
 	// Sequence number of the latest ledger.
 	Sequence uint32 `json:"sequence"`
 }

--- a/events.ts
+++ b/events.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node-script
 
 import { ArgumentParser } from 'argparse';
-import { Contract, SorobanRpc } from 'stellar-sdk';
+import { Contract, SorobanRpc } from '@stellar/stellar-sdk';
 
 async function main() {
   const parser = new ArgumentParser({ description: 'Get contract events' })

--- a/invoke.ts
+++ b/invoke.ts
@@ -8,7 +8,7 @@ import {
   SorobanRpc,
   scValToNative,
   xdr
-} from 'stellar-sdk';
+} from '@stellar/stellar-sdk';
 
 const { Server } = SorobanRpc;
 

--- a/start
+++ b/start
@@ -101,6 +101,11 @@ function main() {
 
   soroban_rpc_status 
 
+  # quickstart runs horizon, but sys tests don't need it.
+  if [ "$LOCAL_CORE" = "true" ]; then
+      supervisorctl stop horizon
+  fi  
+
   print_screen_output "  RUST_TOOLCHAIN_VERSION=$(rustc --version 2>/dev/null || echo"n/a" )"
   print_screen_output "  SOROBAN_CLI_CRATE_VERSION=$(soroban version 2>/dev/null || echo "n/a" )"
   print_screen_output "  SOROBAN_EXAMPLES_GIT_HASH=$SOROBAN_EXAMPLES_GIT_HASH"


### PR DESCRIPTION
Update system test js scripts to use latest js stellar sdk correctly.
Update to use the correct json-rpc/http getLatestLedger response. 