### PR TITLE
Set the PROTOCOL_VERSION_DEFAULT when building quickstart

### DIFF
--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -20,7 +20,7 @@ env:
   PUSH_ENABLED: ${{ secrets.DOCKERHUB_TOKEN && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') != true && 'true' || 'false' }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.ref_type == 'tag' && github.ref_name || github.event.ref || 'latest') }}
   CORE_GIT_REF: https://github.com/stellar/stellar-core.git#master
-  SOROBAN_RPC_GIT_REF: https://github.com/stellar/soroban-tools.git#main
+  SOROBAN_RPC_GIT_REF: https://github.com/stellar/soroban-rpc.git#main
   RUST_TOOLCHAIN_VERSION: stable
   SOROBAN_CLI_GIT_REF: https://github.com/stellar/soroban-tools.git#main
   QUICKSTART_GIT_REF: https://github.com/stellar/quickstart.git#master

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROTOCOL_VERSION_DEFAULT=
 
 # variables to set for source code, can be any valid docker context url local path github remote repo `https://github.com/repo#<ref>`
 CORE_GIT_REF=https://github.com/stellar/stellar-core.git\#master
-SOROBAN_RPC_GIT_REF=https://github.com/stellar/soroban-tools.git\#main
+SOROBAN_RPC_GIT_REF=https://github.com/stellar/soroban-rpc.git\#main
 SOROBAN_CLI_GIT_REF=https://github.com/stellar/soroban-tools.git\#main
 GO_GIT_REF=https://github.com/stellar/go.git\#master
 RS_XDR_GIT_REPO=https://github.com/stellar/rs-stellar-xdr

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ SOROBAN_CLI_STAGE_IMAGE=stellar/system-test-soroban-cli:dev
 
 # The default protocol version that the image should start with. Should
 # typically be set to the maximum supported protocol version of all components.
-PROTOCOL_VERSION_DEFAULT=21
+# If not set will default to the core max supported protocol version in quickstart.
+PROTOCOL_VERSION_DEFAULT=
 
 # variables to set for source code, can be any valid docker context url local path github remote repo `https://github.com/repo#<ref>`
 CORE_GIT_REF=https://github.com/stellar/stellar-core.git\#master

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ SOROBAN_CLI_STAGE_IMAGE=stellar/system-test-soroban-cli:dev
 # The rest of these variables can be set as environment variables to the makefile
 # to modify how system test is built.
 
+# The default protocol version that the image should start with. Should
+# typically be set to the maximum supported protocol version of all components.
+PROTOCOL_VERSION_DEFAULT=21
+
 # variables to set for source code, can be any valid docker context url local path github remote repo `https://github.com/repo#<ref>`
 CORE_GIT_REF=https://github.com/stellar/stellar-core.git\#master
 SOROBAN_RPC_GIT_REF=https://github.com/stellar/soroban-tools.git\#main
@@ -156,6 +160,7 @@ build-quickstart: build-core build-friendbot build-horizon build-rs-xdr build-so
 			SOURCE_URL=.; \
 		fi; \
 		docker build -t "$(QUICKSTART_STAGE_IMAGE)" \
+		--build-arg PROTOCOL_VERSION_DEFAULT=$$PROTOCOL_VERSION_DEFAULT \
 		--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true \
 		--build-arg STELLAR_CORE_IMAGE_REF=$$CORE_IMAGE_REF \
 		--build-arg STELLAR_XDR_IMAGE_REF=$$RS_XDR_IMAGE_REF \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
        SOROBAN_CLI_CRATE_VERSION=? \
        JS_STELLAR_SDK_NPM_VERSION=? \
        NODE_VERSION=? \
+       PROTOCOL_VERSION_DEFAULT=? \
        build
   ```
 
@@ -54,7 +55,7 @@
   JS_STELLAR_SDK_NPM_VERSION=https://github.com/stellar/js-stellar-sdk.git#master
   ```
 
-  optional to set:
+  optional params to set:
   ```
   # this will override SOROBAN_CLI_GIT_REF, and install soroban cli from crates repo instead
   SOROBAN_CLI_CRATE_VERSION=0.4.0
@@ -95,9 +96,14 @@
   # this will skip building friendbot from GO_GIT_REF and instead
   # will use the bin already compiled at /app/friendbot in the existing docker image provided:
   FRIENDBOT_IMAGE=<docker registry>/<docker image name>:<docker tag>
+
+  # set the default network protocol version which the internal core runtime built from `CORE_GIT_REF` should start with. 
+  # Should typically be set to the maximum supported protocol version of all components.
+  # If not set or set to empty, will default to the core max supported protocol version defined in quickstart.
+  PROTOCOL_VERSION_DEFAULT=
   ```
 
-Optional parameters to pass when running system-test image, `stellar/system-test:<tag>`:
+Optional parameters to pass when running the system-test image, `stellar/system-test:<tag>`:
 
 To specify git version of the smart contract source code used in soroban test fixtures.
 `--SorobanExamplesGitHash {branch, tag, git commit hash}`


### PR DESCRIPTION
### What
Set the PROTOCOL_VERSION_DEFAULT when building quickstart.

### Why
The quickstart image now requires the default protocol version to be set as a build argument. This is because the quickstart image can't know what the common maximum supported protocol version is of all of the software in the image. It may be that a stellar-core has support for N, while a Horizon or RPC may only support N-1. We want teams to be able to update their software without coordinating, and for the image still to work if it has a newer stellar-core while it has an older Horizon. 

The system-test image builds quickstart and so needs to set this new parameter.

Related:
- https://github.com/stellar/quickstart/pull/603