### PR TITLE
Remove use of deprecated commands

### DIFF
--- a/features/dapp_develop/main.go
+++ b/features/dapp_develop/main.go
@@ -119,7 +119,6 @@ func installContract(compiledContractFileName string, contractWorkingDirectory s
 
 func createNetworkConfig(configName string, rpcUrl string, networkPassphrase string, e2eConfig *e2e.E2EConfig) error {
 	envCmd := cmd.NewCmd("soroban",
-		"config",
 		"network",
 		"add",
 		"--rpc-url", rpcUrl,

--- a/features/dapp_develop/soroban_config.exp
+++ b/features/dapp_develop/soroban_config.exp
@@ -2,7 +2,7 @@
 set KEY_NAME [lindex $argv 0]
 set KEY [lindex $argv 1]
 set timeout -1
-spawn soroban config identity add --secret-key $KEY_NAME
+spawn soroban keys add --secret-key $KEY_NAME
 expect -exact "Type a secret key: \r"
 send -- "$KEY\r"
 expect eof


### PR DESCRIPTION
### What
Remove use of the soroban config commands from tests.

### Why
The soroban config commands have been deprecated for a while and replaced with other commands. Soon the deprecated commands will be deleted.