### PR TITLE
fix: support latest soroban-examples

### DIFF
--- a/features/dapp_develop/dapp_develop.feature
+++ b/features/dapp_develop/dapp_develop.feature
@@ -12,7 +12,7 @@ Scenario Outline: DApp developer compiles, installs, deploys and invokes a contr
 
   Examples: 
         | Tool         | ContractExampleSubPath | ContractName                  | ContractCompiledFileName             | FunctionName | FunctionParams | Result             |
-        | NODEJS       | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | Aloha          | ["Hello","Aloha"]  |
+        | NODEJS       | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | to:'Aloha'     | ["Hello","Aloha"]  |
         | CLI          | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | --to=Aloha     | ["Hello","Aloha"]  |
         | NODEJS       | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  |
         | CLI          | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  |
@@ -30,7 +30,7 @@ Scenario Outline: DApp developer compiles, deploys and invokes a contract
 
   Examples: 
         | Tool         | ContractExampleSubPath | ContractName                  | ContractCompiledFileName             | FunctionName | FunctionParams | Result             | EventCount | DiagEventCount |
-        | NODEJS       | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | Aloha          | ["Hello","Aloha"]  | 0          | 1              |
+        | NODEJS       | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | to:'Aloha'     | ["Hello","Aloha"]  | 0          | 1              |
         | CLI          | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | --to=Aloha     | ["Hello","Aloha"]  | 0          | 1              |
         | NODEJS       | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  | 0          | 1              |
         | CLI          | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  | 0          | 1              |


### PR DESCRIPTION
The system-test started failing in https://github.com/stellar/stellar-cli/pull/1500 because it finally updated the version of `soroban-examples` to use a version that includes https://github.com/stellar/soroban-examples/pull/314. The previous `invoke.ts` logic assumed that the variable would be a Symbol, but the variable has been changed to a String.

I don't want to break every project that still uses `system-test` with a stale `soroban-examples` hash, so here's what I did:

- dynamically define `contract` using `import()`, using a `@ts-ignore` directive because this can error if `stellar-sdk` doesn't include a `contract` export.
- if `contract` is there, then we don't need to know the type of the argument. It could be a Symbol or a String or anything else.
- non-`contract` logic path stays unchanged, assuming `Symbol`