### PR TITLE
Always send in system-tests

### DIFF
--- a/features/dapp_develop/cli.go
+++ b/features/dapp_develop/cli.go
@@ -20,6 +20,7 @@ func invokeContractFromCliTool(deployedContractId, contractName, functionName, f
 		"--rpc-url", e2eConfig.TargetNetworkRPCURL,
 		"--source", e2eConfig.TargetNetworkSecretKey,
 		"--network-passphrase", e2eConfig.TargetNetworkPassPhrase,
+		"--send", "yes",
 		"--",
 		functionName,
 	}


### PR DESCRIPTION
### What
Always send invocations in system-tests with the CLI.

### Why
The system-tests assume that transactions are always being sent, however the CLI no longer always sends transactions to the network.

We probably want to add tests to the system-tests relating to those non-sent situations, but for the moment this change is just addressing maintaining the same behavior for the existing tests.

Related:
- https://github.com/stellar/stellar-cli/pull/1536