### PR TITLE
update the test ts script to use newer js sdk export names

### DIFF
--- a/events.ts
+++ b/events.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node-script
 
 import { ArgumentParser } from 'argparse';
-import { Contract, SorobanRpc } from '@stellar/stellar-sdk';
+import { Contract, rpc } from '@stellar/stellar-sdk';
 
 async function main() {
   const parser = new ArgumentParser({ description: 'Get contract events' })
@@ -17,9 +17,9 @@ async function main() {
     ledgerFrom,
   } = parser.parse_args() as Record<string, string>;
 
-  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: true });
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
 
-  let filters: SorobanRpc.Api.EventFilter[] = [];
+  let filters: rpc.Api.EventFilter[] = [];
 
   if (contractId != null) {
     filters.push({

--- a/invoke.ts
+++ b/invoke.ts
@@ -5,13 +5,11 @@ import { ArgumentParser } from 'argparse';
 import {
   Contract,
   Keypair,
+  rpc,
   TransactionBuilder,
-  SorobanRpc,
   scValToNative,
   xdr,
 } from '@stellar/stellar-sdk';
-
-const { Server } = SorobanRpc;
 
 async function main() {
   const parser = new ArgumentParser({ description: 'Invoke a contract function' })
@@ -61,7 +59,7 @@ async function main() {
     console.log(JSON.stringify(result));
     return;
   } else {
-    const server = new Server(rpcUrl, { allowHttp: true });
+    const server = new rpc.Server(rpcUrl, { allowHttp: true });
     const sourceAccount = await server.getAccount(account);
     const contract = new Contract(contractId);
     // Some hacky param-parsing as csv. Generated Typescript bindings would be better.


### PR DESCRIPTION
updated system test's ts scripts as clients to use newer 13.x js sdk version export names, it was using 12.x which exported differently, can see the error on [rpc CI runs](https://github.com/stellar/stellar-rpc/actions/runs/12393628468/job/34595281000)