### PR TITLE
update system to handle latest behviors

### DIFF
--- a/features/dapp_develop/cli.go
+++ b/features/dapp_develop/cli.go
@@ -3,6 +3,7 @@ package dapp_develop
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/go-cmd/cmd"
@@ -99,7 +100,8 @@ func getEventsFromCliTool(ledgerFrom uint32, deployedContractId string, size uin
 	}
 
 	// put commas between any json event objects if more than one found
-	stdOutEventsValidJson := strings.ReplaceAll(strings.Join(stdOutLines, "\n"), `\n}\n{\n`, `\n}\n,\n{\n`)
+	regex := regexp.MustCompile(`\n}\n{\n`) // Create a regex pattern
+	stdOutEventsValidJson := regex.ReplaceAllString(strings.Join(stdOutLines, "\n"), "\n}\n,\n{\n")
 	// wrap the json objects in json array brackets
 	stdOutEventsValidJson = "[" + stdOutEventsValidJson + "]"
 

--- a/features/dapp_develop/dapp_develop.feature
+++ b/features/dapp_develop/dapp_develop.feature
@@ -30,10 +30,10 @@ Scenario Outline: DApp developer compiles, deploys and invokes a contract
 
   Examples: 
         | Tool         | ContractExampleSubPath | ContractName                  | ContractCompiledFileName             | FunctionName | FunctionParams | Result             | EventCount | DiagEventCount |
-        | NODEJS       | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | to:Aloha       | ["Hello","Aloha"]  | 0          | 1              |
-        | CLI          | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | --to=Aloha     | ["Hello","Aloha"]  | 0          | 1              |
-        | NODEJS       | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  | 0          | 1              |
-        | CLI          | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  | 0          | 1              |
+        | NODEJS       | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | to:Aloha       | ["Hello","Aloha"]  | 0          | 2              |
+        | CLI          | hello_world            | soroban-hello-world-contract  | soroban_hello_world_contract.wasm    | hello        | --to=Aloha     | ["Hello","Aloha"]  | 0          | 2              |
+        | NODEJS       | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  | 0          | 2              |
+        | CLI          | increment              | soroban-increment-contract    | soroban_increment_contract.wasm      | increment    |                | 1                  | 0          | 2              |
 
 
 Scenario Outline: DApp developer uses config states, compiles, deploys and invokes contract with authorizations

--- a/features/dapp_develop/soroban_config.exp
+++ b/features/dapp_develop/soroban_config.exp
@@ -3,6 +3,6 @@ set KEY_NAME [lindex $argv 0]
 set KEY [lindex $argv 1]
 set timeout -1
 spawn soroban keys add --secret-key $KEY_NAME
-expect -exact "Type a secret key: \r"
+expect "Type a secret key"
 send -- "$KEY\r"
 expect eof


### PR DESCRIPTION
needed to change system test for different system behaviors:

* diag events are showing up from contract creation, changed verify to be aware of this
* `soroban keys` command has different input 

[rpc CI](https://github.com/stellar/stellar-rpc/pull/342) uses the newer system versions and is currently blocked on this, once this merges, then re-run the e2e step to pull in the updates.