### PR TITLE
Add libudev-dev and libdbus-1-dev to system path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG RUST_TOOLCHAIN_VERSION
 ARG NODE_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y build-essential expect git && apt-get clean
+RUN apt-get update && apt-get install -y build-essential expect git libdbus-1-dev libudev-dev && apt-get clean
 
 # Install Rust
 RUN ["mkdir", "-p", "/rust"]


### PR DESCRIPTION
closes #116 

This PR adds two dependencies:
- libudev-dev: this is required for forthcoming ledger signing support
- libdbus-1-dev: this is required by the `keyring` crate that we're using to do keychain signing