### PR TITLE
Install rust toolchain

### DIFF
--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -23,7 +23,7 @@ env:
   STELLAR_RPC_GIT_REF: https://github.com/stellar/stellar-rpc.git#main
   RUST_TOOLCHAIN_VERSION: stable
   SOROBAN_CLI_GIT_REF: https://github.com/stellar/soroban-tools.git#main
-  QUICKSTART_GIT_REF: https://github.com/stellar/quickstart.git#e1f62bf34cf047156dbb599b3c7dff52283ac696
+  QUICKSTART_GIT_REF: https://github.com/stellar/quickstart.git#38176e8aa7aad5c7eabadc065534bec371681292
   # leaving sdk npm version blank defaults to whatever npm has for latest version
   # rather than build from git source, which is fine for ci test build
   JS_STELLAR_SDK_NPM_VERSION: 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ENV RUSTUP_HOME=/rust/.rust
 ENV RUST_TOOLCHAIN_VERSION=$RUST_TOOLCHAIN_VERSION
 ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN_VERSION"
+RUN rustup show active-toolchain || rustup toolchain install
 
 # Use a non-root user
 ARG USERNAME=tester

--- a/Dockerfile.soroban-cli
+++ b/Dockerfile.soroban-cli
@@ -7,6 +7,7 @@ WORKDIR /soroban-tools
 COPY . .
 
 run apt update && apt install -y libdbus-1-dev libudev-dev
+RUN rustup show active-toolchain || rustup toolchain install
 run if [ ! -z "$SOROBAN_CLI_CRATE_VERSION" ]; then \
 		cargo install \
 		--config net.git-fetch-with-cli=true \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SOROBAN_CLI_STAGE_IMAGE=stellar/system-test-soroban-cli:dev
 # The default protocol version that the image should start with. Should
 # typically be set to the maximum supported protocol version of all components.
 # If not set will default to the core max supported protocol version in quickstart.
-PROTOCOL_VERSION_DEFAULT=
+PROTOCOL_VERSION_DEFAULT=22
 
 # variables to set for source code, can be any valid docker context url local path github remote repo `https://github.com/repo#<ref>`
 CORE_GIT_REF=https://github.com/stellar/stellar-core.git\#master


### PR DESCRIPTION
Starting with v1.28, rustup is not going to install active toolchain by default see https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280