### PR TITLE
Install older toolchain for Soroban examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ ENV RUST_TOOLCHAIN_VERSION=$RUST_TOOLCHAIN_VERSION
 ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN_VERSION"
 RUN rustup show active-toolchain || rustup toolchain install
+# Older toolchain to compile soroban examples
+RUN rustup toolchain install 1.81-x86_64-unknown-linux-gnu
 
 # Use a non-root user
 ARG USERNAME=tester


### PR DESCRIPTION
We are missing 1.81 toolchain required for Soroban examples. It's currently pinned to an older version and is required to compile examples code.