### PR TITLE
Copy stellar from soroban-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ USER root
 
 ADD start /home/tester
 COPY --from=soroban-cli /usr/local/cargo/bin/soroban $CARGO_HOME/bin/
+COPY --from=soroban-cli /usr/local/cargo/bin/stellar $CARGO_HOME/bin/
 COPY --from=go /test/bin/ /home/tester/bin
 
 ENTRYPOINT ["/home/tester/start"]


### PR DESCRIPTION
In #119 I replaced legacy command `soroban` with `stellar` but it was not properly copied in the docker file